### PR TITLE
[FEATURE] separate sketching and layouting.

### DIFF
--- a/include/hibf/layout/compute_layout.hpp
+++ b/include/hibf/layout/compute_layout.hpp
@@ -10,14 +10,14 @@
 namespace seqan::hibf::layout
 {
 
-/*!\brief Computes the layout and stores the kmer_counts and sketches in the respective vectors for further use.
+/*!\brief Computes the layout.
  * \ingroup hibf_layout
- * \param config The configuration to compute the layout with.
- * \param[in,out] kmer_counts The vector that will store the kmer counts (estimations).
- * \param[in,out] sketches The vector that will store the sketches.
+ * \param[in] config The configuration to compute the layout with.
+ * \param[in] kmer_counts The vector that will store the kmer counts (estimations).
+ * \param[in] sketches The vector that will store the sketches.
  * \returns layout
  */
 layout
-compute_layout(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches);
+compute_layout(config const & config, std::vector<size_t> const & kmer_counts, std::vector<sketch::hyperloglog> const & sketches);
 
 } // namespace seqan::hibf::layout

--- a/include/hibf/layout/compute_layout.hpp
+++ b/include/hibf/layout/compute_layout.hpp
@@ -17,7 +17,8 @@ namespace seqan::hibf::layout
  * \param[in] sketches The vector that will store the sketches.
  * \returns layout
  */
-layout
-compute_layout(config const & config, std::vector<size_t> const & kmer_counts, std::vector<sketch::hyperloglog> const & sketches);
+layout compute_layout(config const & config,
+                      std::vector<size_t> const & kmer_counts,
+                      std::vector<sketch::hyperloglog> const & sketches);
 
 } // namespace seqan::hibf::layout

--- a/include/hibf/sketch/compute_sketches.hpp
+++ b/include/hibf/sketch/compute_sketches.hpp
@@ -9,12 +9,11 @@
 namespace seqan::hibf::sketch
 {
 
-/*!\brief Computes the layout and stores the kmer_counts and sketches in the respective vectors for further use.
+/*!\brief Computes the kmer_counts and sketches and stores them in the respective vectors for further use.
  * \ingroup hibf_layout
- * \param config The configuration to compute the layout with.
+ * \param[in] config The configuration to compute the layout with.
  * \param[in,out] kmer_counts The vector that will store the kmer counts (estimations).
  * \param[in,out] sketches The vector that will store the sketches.
- * \returns layout
  */
 void compute_sketches(config const & config,
                       std::vector<size_t> & kmer_counts,

--- a/include/hibf/sketch/compute_sketches.hpp
+++ b/include/hibf/sketch/compute_sketches.hpp
@@ -16,7 +16,8 @@ namespace seqan::hibf::sketch
  * \param[in,out] sketches The vector that will store the sketches.
  * \returns layout
  */
-void
-compute_sketches(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches);
+void compute_sketches(config const & config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & sketches);
 
 } // namespace seqan::hibf::sketch

--- a/include/hibf/sketch/compute_sketches.hpp
+++ b/include/hibf/sketch/compute_sketches.hpp
@@ -4,10 +4,9 @@
 #include <vector>  // for vector
 
 #include <hibf/config.hpp>             // for config
-#include <hibf/layout/layout.hpp>      // for layout
 #include <hibf/sketch/hyperloglog.hpp> // for hyperloglog
 
-namespace seqan::hibf::layout
+namespace seqan::hibf::sketch
 {
 
 /*!\brief Computes the layout and stores the kmer_counts and sketches in the respective vectors for further use.
@@ -17,7 +16,7 @@ namespace seqan::hibf::layout
  * \param[in,out] sketches The vector that will store the sketches.
  * \returns layout
  */
-layout
-compute_layout(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches);
+void
+compute_sketches(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches);
 
-} // namespace seqan::hibf::layout
+} // namespace seqan::hibf::sketch

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set (HIBF_SOURCE_FILES
      layout/layout.cpp
      layout/compute_fpr_correction.cpp
      layout/compute_layout.cpp
-     layout/compute_sketches.cpp
+     sketch/compute_sketches.cpp
      layout/graph.cpp
      layout/hierarchical_binning.cpp
      misc/print.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set (HIBF_SOURCE_FILES
      layout/layout.cpp
      layout/compute_fpr_correction.cpp
      layout/compute_layout.cpp
+     layout/compute_sketches.cpp
      layout/graph.cpp
      layout/hierarchical_binning.cpp
      misc/print.cpp

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -29,8 +29,8 @@
 #include <hibf/layout/compute_layout.hpp>                 // for compute_layout
 #include <hibf/layout/graph.hpp>                          // for graph
 #include <hibf/layout/layout.hpp>                         // for layout
-#include <hibf/sketch/compute_sketches.hpp>               // for compute_sketches
 #include <hibf/misc/timer.hpp>                            // for timer
+#include <hibf/sketch/compute_sketches.hpp>               // for compute_sketches
 
 namespace seqan::hibf
 {

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -29,6 +29,7 @@
 #include <hibf/layout/compute_layout.hpp>                 // for compute_layout
 #include <hibf/layout/graph.hpp>                          // for graph
 #include <hibf/layout/layout.hpp>                         // for layout
+#include <hibf/sketch/compute_sketches.hpp>               // for compute_sketches
 #include <hibf/misc/timer.hpp>                            // for timer
 
 namespace seqan::hibf
@@ -197,7 +198,12 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(config & configuration)
 {
     configuration.validate_and_set_defaults();
-    auto layout = layout::compute_layout(configuration);
+
+    std::vector<size_t> kmer_counts{};
+    std::vector<sketch::hyperloglog> sketches{};
+    sketch::compute_sketches(configuration, kmer_counts, sketches);
+
+    auto layout = layout::compute_layout(configuration, kmer_counts, sketches);
     build_index(*this, configuration, layout);
 }
 

--- a/src/layout/compute_layout.cpp
+++ b/src/layout/compute_layout.cpp
@@ -21,7 +21,7 @@ namespace seqan::hibf::layout
 {
 
 layout
-compute_layout(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches)
+compute_layout(config const & config, std::vector<size_t> const & kmer_counts, std::vector<sketch::hyperloglog> const & sketches)
 {
     layout resulting_layout{};
 
@@ -29,28 +29,6 @@ compute_layout(config const & config, std::vector<size_t> & kmer_counts, std::ve
     // seqan::hibf::execute currently writes the filled buffers to the output file.
     std::stringstream output_buffer;
     std::stringstream header_buffer;
-
-    // compute sketches
-    sketches.resize(config.number_of_user_bins);
-    kmer_counts.resize(config.number_of_user_bins);
-
-    robin_hood::unordered_flat_set<uint64_t> kmers;
-#pragma omp parallel for schedule(dynamic) num_threads(config.threads) private(kmers)
-    for (size_t i = 0; i < config.number_of_user_bins; ++i)
-    {
-        seqan::hibf::sketch::hyperloglog sketch(config.sketch_bits);
-
-        kmers.clear();
-        config.input_fn(i, std::inserter(kmers, kmers.begin()));
-
-        for (auto k_hash : kmers)
-            sketch.add(k_hash);
-
-        // #pragma omp critical
-        sketches[i] = sketch;
-    }
-
-    sketch::estimate_kmer_counts(sketches, kmer_counts);
 
     data_store store{.false_positive_rate = config.maximum_false_positive_rate,
                      .hibf_layout = &resulting_layout,
@@ -72,14 +50,6 @@ compute_layout(config const & config, std::vector<size_t> & kmer_counts, std::ve
     // GCOVR_EXCL_STOP
 
     return *store.hibf_layout;
-}
-
-layout compute_layout(config const & config)
-{
-    std::vector<size_t> kmer_counts{};
-    std::vector<sketch::hyperloglog> sketches{};
-
-    return compute_layout(config, kmer_counts, sketches);
 }
 
 } // namespace seqan::hibf::layout

--- a/src/layout/compute_layout.cpp
+++ b/src/layout/compute_layout.cpp
@@ -20,8 +20,9 @@
 namespace seqan::hibf::layout
 {
 
-layout
-compute_layout(config const & config, std::vector<size_t> const & kmer_counts, std::vector<sketch::hyperloglog> const & sketches)
+layout compute_layout(config const & config,
+                      std::vector<size_t> const & kmer_counts,
+                      std::vector<sketch::hyperloglog> const & sketches)
 {
     layout resulting_layout{};
 

--- a/src/sketch/compute_sketches.cpp
+++ b/src/sketch/compute_sketches.cpp
@@ -7,15 +7,16 @@
 #include <utility>    // for addressof
 #include <vector>     // for vector
 
-#include <hibf/contrib/robin_hood.hpp>            // for unordered_flat_set
-#include <hibf/sketch/compute_sketches.hpp>       // for compute_sketches
-#include <hibf/sketch/estimate_kmer_counts.hpp>   // for estimate_kmer_counts
+#include <hibf/contrib/robin_hood.hpp>          // for unordered_flat_set
+#include <hibf/sketch/compute_sketches.hpp>     // for compute_sketches
+#include <hibf/sketch/estimate_kmer_counts.hpp> // for estimate_kmer_counts
 
 namespace seqan::hibf::sketch
 {
 
-void
-compute_sketches(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches)
+void compute_sketches(config const & config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & sketches)
 {
     // compute sketches
     sketches.resize(config.number_of_user_bins);
@@ -40,4 +41,4 @@ compute_sketches(config const & config, std::vector<size_t> & kmer_counts, std::
     sketch::estimate_kmer_counts(sketches, kmer_counts);
 }
 
-} // namespace seqan::hibf::sketches
+} // namespace seqan::hibf::sketch

--- a/src/sketch/compute_sketches.cpp
+++ b/src/sketch/compute_sketches.cpp
@@ -1,0 +1,43 @@
+#include <algorithm>  // for __sort_fn, sort
+#include <cinttypes>  // for uint64_t
+#include <cstddef>    // for size_t
+#include <functional> // for identity, function
+#include <iterator>   // for inserter
+#include <sstream>    // for basic_stringstream, stringstream
+#include <utility>    // for addressof
+#include <vector>     // for vector
+
+#include <hibf/contrib/robin_hood.hpp>            // for unordered_flat_set
+#include <hibf/sketch/compute_sketches.hpp>       // for compute_sketches
+#include <hibf/sketch/estimate_kmer_counts.hpp>   // for estimate_kmer_counts
+
+namespace seqan::hibf::sketch
+{
+
+void
+compute_sketches(config const & config, std::vector<size_t> & kmer_counts, std::vector<sketch::hyperloglog> & sketches)
+{
+    // compute sketches
+    sketches.resize(config.number_of_user_bins);
+    kmer_counts.resize(config.number_of_user_bins);
+
+    robin_hood::unordered_flat_set<uint64_t> kmers;
+#pragma omp parallel for schedule(dynamic) num_threads(config.threads) private(kmers)
+    for (size_t i = 0; i < config.number_of_user_bins; ++i)
+    {
+        seqan::hibf::sketch::hyperloglog sketch(config.sketch_bits);
+
+        kmers.clear();
+        config.input_fn(i, std::inserter(kmers, kmers.begin()));
+
+        for (auto k_hash : kmers)
+            sketch.add(k_hash);
+
+        // #pragma omp critical
+        sketches[i] = sketch;
+    }
+
+    sketch::estimate_kmer_counts(sketches, kmer_counts);
+}
+
+} // namespace seqan::hibf::sketches


### PR DESCRIPTION
This is needed such that I can try to build an partioned HIBF in raptor instead of the hibf lib. That way raptor can compute the sketches by itself and then forward them to the `compute_layout` function.