### PR TITLE
[MISC] Fix some clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,11 @@
 Checks: "bugprone*,
          performance*,
          -bugprone-easily-swappable-parameters
+         -bugprone-exception-escape
+         -bugprone-narrowing-conversions
 "
 WarningsAsErrors: ''
-HeaderFilterRegex: '.*/include/hibf/(.*.hpp|detail/.*|std/.*)'
+HeaderFilterRegex: '.*/include/hibf/.*\.hpp'
 FormatStyle:     none
+ExtraArgs:
+- -Wno-unknown-pragmas

--- a/include/hibf/contrib/robin_hood.hpp
+++ b/include/hibf/contrib/robin_hood.hpp
@@ -30,6 +30,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// NOLINTBEGIN(performance-noexcept-swap)
 #ifndef ROBIN_HOOD_H_INCLUDED
 #define ROBIN_HOOD_H_INCLUDED
 
@@ -2543,3 +2544,4 @@ using unordered_set = detail::Table<sizeof(Key) <= sizeof(size_t) * 6 &&
 
 #endif
 
+// NOLINTEND(performance-noexcept-swap)

--- a/include/hibf/interleaved_bloom_filter.hpp
+++ b/include/hibf/interleaved_bloom_filter.hpp
@@ -192,12 +192,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    interleaved_bloom_filter() = default;                                             //!< Defaulted.
-    interleaved_bloom_filter(interleaved_bloom_filter const &) = default;             //!< Defaulted.
-    interleaved_bloom_filter & operator=(interleaved_bloom_filter const &) = default; //!< Defaulted.
-    interleaved_bloom_filter(interleaved_bloom_filter &&) = default;                  //!< Defaulted.
-    interleaved_bloom_filter & operator=(interleaved_bloom_filter &&) = default;      //!< Defaulted.
-    ~interleaved_bloom_filter() = default;                                            //!< Defaulted.
+    interleaved_bloom_filter() = default;                                                 //!< Defaulted.
+    interleaved_bloom_filter(interleaved_bloom_filter const &) = default;                 //!< Defaulted.
+    interleaved_bloom_filter & operator=(interleaved_bloom_filter const &) = default;     //!< Defaulted.
+    interleaved_bloom_filter(interleaved_bloom_filter &&) noexcept = default;             //!< Defaulted.
+    interleaved_bloom_filter & operator=(interleaved_bloom_filter &&) noexcept = default; //!< Defaulted.
+    ~interleaved_bloom_filter() = default;                                                //!< Defaulted.
 
     /*!\brief Construct an uncompressed Interleaved Bloom Filter.
      * \param bins_ The number of bins.
@@ -472,12 +472,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    binning_bitvector() = default;                                      //!< Defaulted.
-    binning_bitvector(binning_bitvector const &) = default;             //!< Defaulted.
-    binning_bitvector & operator=(binning_bitvector const &) = default; //!< Defaulted.
-    binning_bitvector(binning_bitvector &&) = default;                  //!< Defaulted.
-    binning_bitvector & operator=(binning_bitvector &&) = default;      //!< Defaulted.
-    ~binning_bitvector() = default;                                     //!< Defaulted.
+    binning_bitvector() = default;                                          //!< Defaulted.
+    binning_bitvector(binning_bitvector const &) = default;                 //!< Defaulted.
+    binning_bitvector & operator=(binning_bitvector const &) = default;     //!< Defaulted.
+    binning_bitvector(binning_bitvector &&) noexcept = default;             //!< Defaulted.
+    binning_bitvector & operator=(binning_bitvector &&) noexcept = default; //!< Defaulted.
+    ~binning_bitvector() = default;                                         //!< Defaulted.
 
     //!\brief Construct with given size.
     explicit binning_bitvector(size_t const size) : data(size)
@@ -597,12 +597,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    membership_agent_type() = default;                                          //!< Defaulted.
-    membership_agent_type(membership_agent_type const &) = default;             //!< Defaulted.
-    membership_agent_type & operator=(membership_agent_type const &) = default; //!< Defaulted.
-    membership_agent_type(membership_agent_type &&) = default;                  //!< Defaulted.
-    membership_agent_type & operator=(membership_agent_type &&) = default;      //!< Defaulted.
-    ~membership_agent_type() = default;                                         //!< Defaulted.
+    membership_agent_type() = default;                                              //!< Defaulted.
+    membership_agent_type(membership_agent_type const &) = default;                 //!< Defaulted.
+    membership_agent_type & operator=(membership_agent_type const &) = default;     //!< Defaulted.
+    membership_agent_type(membership_agent_type &&) noexcept = default;             //!< Defaulted.
+    membership_agent_type & operator=(membership_agent_type &&) noexcept = default; //!< Defaulted.
+    ~membership_agent_type() = default;                                             //!< Defaulted.
 
     /*!\brief Construct a membership_agent_type from a seqan::hibf::interleaved_bloom_filter.
      * \private
@@ -827,12 +827,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    counting_agent_type() = default;                                        //!< Defaulted.
-    counting_agent_type(counting_agent_type const &) = default;             //!< Defaulted.
-    counting_agent_type & operator=(counting_agent_type const &) = default; //!< Defaulted.
-    counting_agent_type(counting_agent_type &&) = default;                  //!< Defaulted.
-    counting_agent_type & operator=(counting_agent_type &&) = default;      //!< Defaulted.
-    ~counting_agent_type() = default;                                       //!< Defaulted.
+    counting_agent_type() = default;                                            //!< Defaulted.
+    counting_agent_type(counting_agent_type const &) = default;                 //!< Defaulted.
+    counting_agent_type & operator=(counting_agent_type const &) = default;     //!< Defaulted.
+    counting_agent_type(counting_agent_type &&) noexcept = default;             //!< Defaulted.
+    counting_agent_type & operator=(counting_agent_type &&) noexcept = default; //!< Defaulted.
+    ~counting_agent_type() = default;                                           //!< Defaulted.
 
     /*!\brief Construct a counting_agent_type for an existing seqan::hibf::interleaved_bloom_filter.
      * \private

--- a/include/hibf/misc/insert_iterator.hpp
+++ b/include/hibf/misc/insert_iterator.hpp
@@ -49,12 +49,12 @@ public:
         if (is_set)
         {
             assert(set != nullptr);
-            set->emplace(std::move(value));
+            set->emplace(value);
         }
         else
         {
             assert(vec != nullptr);
-            vec->emplace_back(std::move(value));
+            vec->emplace_back(value);
         }
         return *this;
     }

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -187,10 +187,12 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
 
     hierarchical_build(hibf, root_node, data);
 
+    // NOLINTBEGIN(performance-move-const-arg)
     hibf.index_allocation_timer = std::move(data.index_allocation_timer);
     hibf.user_bin_io_timer = std::move(data.user_bin_io_timer);
     hibf.merge_kmers_timer = std::move(data.merge_kmers_timer);
     hibf.fill_ibf_timer = std::move(data.fill_ibf_timer);
+    // NOLINTEND(performance-move-const-arg)
 }
 
 hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(config & configuration)

--- a/src/interleaved_bloom_filter.cpp
+++ b/src/interleaved_bloom_filter.cpp
@@ -70,6 +70,7 @@ interleaved_bloom_filter::interleaved_bloom_filter(config & configuration) :
                              seqan::hibf::bin_size{max_bin_size(configuration)},
                              seqan::hibf::hash_function_count{configuration.number_of_hash_functions}}
 {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     size_t const chunk_size = std::clamp<size_t>(std::bit_ceil(bin_count() / configuration.threads), 8u, 64u);
     robin_hood::unordered_flat_set<uint64_t> kmers;
 

--- a/src/layout/graph.cpp
+++ b/src/layout/graph.cpp
@@ -64,7 +64,7 @@ void update_content_node_data(std::vector<layout::layout::user_bin> const & layo
     // -------------------------------------------------------------------------
     for (size_t user_bin = 0; user_bin < layout_user_bins.size(); ++user_bin)
     {
-        auto & record = layout_user_bins[user_bin]; // Not const because std::move(const&) will copy, not move
+        auto const & record = layout_user_bins[user_bin];
 
         // go down the tree until you find the matching parent
         seqan::hibf::layout::graph::node * current_node = &ibf_graph.root; // start at root
@@ -101,9 +101,9 @@ void update_content_node_data(std::vector<layout::layout::user_bin> const & layo
         current_node->number_of_technical_bins = std::max(current_node->number_of_technical_bins, bin + num_tbs);
 
         if (record.storage_TB_id == current_node->max_bin_index)
-            current_node->remaining_records.insert(current_node->remaining_records.begin(), std::move(record));
+            current_node->remaining_records.insert(current_node->remaining_records.begin(), record);
         else
-            current_node->remaining_records.emplace_back(std::move(record));
+            current_node->remaining_records.emplace_back(record);
     }
 }
 

--- a/src/layout/hierarchical_binning.cpp
+++ b/src/layout/hierarchical_binning.cpp
@@ -276,8 +276,10 @@ void hierarchical_binning::backtrack_split_bin(size_t trace_j,
                                                size_t & high_level_max_id,
                                                size_t & high_level_max_size)
 {
+    assert(number_of_bins > 0u);
     size_t cardinality = (*data->kmer_counts)[data->positions[trace_j]];
     size_t const corrected_cardinality = static_cast<size_t>(cardinality * data->fpr_correction[number_of_bins]);
+    // NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
     size_t const cardinality_per_bin = (corrected_cardinality + number_of_bins - 1) / number_of_bins; // round up
 
     data->hibf_layout->user_bins.emplace_back(data->previous.bin_indices,

--- a/src/layout/simple_binning.cpp
+++ b/src/layout/simple_binning.cpp
@@ -18,6 +18,8 @@ namespace seqan::hibf::layout
 size_t simple_binning::execute()
 {
     assert(data != nullptr);
+    assert(num_technical_bins > 0u);
+    assert(num_user_bins > 0u);
 
     std::vector<std::vector<size_t>> matrix(num_technical_bins); // rows
     for (auto & v : matrix)
@@ -100,6 +102,7 @@ size_t simple_binning::execute()
     ++trace_i; // because we want the length not the index. Now trace_i == number_of_bins
     size_t const cardinality = (*data->kmer_counts)[data->positions[0]];
     size_t const corrected_cardinality = static_cast<size_t>(cardinality * data->fpr_correction[trace_i]);
+    // NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
     size_t const cardinality_per_bin = (corrected_cardinality + trace_i - 1) / trace_i;
 
     data->hibf_layout->user_bins.emplace_back(data->previous.bin_indices, bin_id, trace_i, data->positions[0]);


### PR DESCRIPTION
Mainly move ctor/assignment not begin `noexcept` and move of const variables (which has no effect).