### PR TITLE
[FEATURE] Allow a higher false positive rate on merged bins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ int main()
     seqan::hibf::config config{.input_fn = get_user_bin_data, // required
                                .number_of_user_bins = 3u,     // required
                                .number_of_hash_functions = 2u,
-                               .maximum_false_positive_rate = 0.05,
+                               .maximum_fpr = 0.05,
                                .threads = 1u};
 
     // The HIBF constructor will determine a hierarchical layout for the user bins and build the filter.

--- a/include/hibf/config.hpp
+++ b/include/hibf/config.hpp
@@ -30,20 +30,20 @@ namespace seqan::hibf
  *
  * Here is the list of all configs options:
  *
- * | Type    |  Option Name                                                | Default | Note                   |
- * |:--------|:------------------------------------------------------------|:-------:|:-----------------------|
- * | General | seqan::hibf::config::input_fn                               | -       | [REQUIRED]             |
- * | General | seqan::hibf::config::number_of_user_bins                    | -       | [REQUIRED]             |
- * | General | seqan::hibf::config::number_of_hash_functions               | 2       |                        |
- * | General | seqan::hibf::config::maximum_false_positive_rate            | 0.05    | [RECOMMENDED_TO_ADAPT] |
- * | General | seqan::hibf::config::relaxed_fpr | 0.3     |                        |
- * | General | seqan::hibf::config::threads                                | 1       | [RECOMMENDED_TO_ADAPT] |
- * | Layout  | seqan::hibf::config::sketch_bits                            | 12      |                        |
- * | Layout  | seqan::hibf::config::tmax                                   | 0       | 0 indicates unset      |
- * | Layout  | seqan::hibf::config::max_rearrangement_ratio                | 0.5     |                        |
- * | Layout  | seqan::hibf::config::alpha                                  | 1.2     |                        |
- * | Layout  | seqan::hibf::config::disable_estimate_union                 | false   |                        |
- * | Layout  | seqan::hibf::config::disable_rearrangement                  | false   |                        |
+ * | Type    |  Option Name                                  | Default | Note                   |
+ * |:--------|:----------------------------------------------|:-------:|:-----------------------|
+ * | General | seqan::hibf::config::input_fn                 | -       | [REQUIRED]             |
+ * | General | seqan::hibf::config::number_of_user_bins      | -       | [REQUIRED]             |
+ * | General | seqan::hibf::config::number_of_hash_functions | 2       |                        |
+ * | General | seqan::hibf::config::maximum_fpr              | 0.05    | [RECOMMENDED_TO_ADAPT] |
+ * | General | seqan::hibf::config::relaxed_fpr              | 0.3     |                        |
+ * | General | seqan::hibf::config::threads                  | 1       | [RECOMMENDED_TO_ADAPT] |
+ * | Layout  | seqan::hibf::config::sketch_bits              | 12      |                        |
+ * | Layout  | seqan::hibf::config::tmax                     | 0       | 0 indicates unset      |
+ * | Layout  | seqan::hibf::config::max_rearrangement_ratio  | 0.5     |                        |
+ * | Layout  | seqan::hibf::config::alpha                    | 1.2     |                        |
+ * | Layout  | seqan::hibf::config::disable_estimate_union   | false   |                        |
+ * | Layout  | seqan::hibf::config::disable_rearrangement    | false   |                        |
  *
  * As a copy and paste source, here are all config options with their defaults:
  *
@@ -62,7 +62,7 @@ namespace seqan::hibf
  * Check the documentation of the following options that influence the memory consumption:
  * * seqan::hibf::config::threads
  * * seqan::hibf::config::number_of_hash_functions
- * * seqan::hibf::config::maximum_false_positive_rate
+ * * seqan::hibf::config::maximum_fpr
  *
  * ## Validation
  *
@@ -134,7 +134,7 @@ struct config
     /*!\brief The desired maximum false positive rate of the underlying Bloom Filters. [RECOMMENDED_TO_ADAPT]
      *
      * We ensure that when querying a single hash value in the (H)IBF, the probability of getting a false positive answer
-     * will not exceed the value set for seqan::hibf::config::maximum_false_positive_rate.
+     * will not exceed the value set for seqan::hibf::config::maximum_fpr.
      * The internal Bloom Filters will be configured accordingly. Individual Bloom Filters might have a different
      * but always lower false positive rate (FPR).
      *
@@ -147,30 +147,30 @@ struct config
      *
      * \sa [Bloom Filter Calculator](https://hur.st/bloomfilter/).
      */
-    double maximum_false_positive_rate{0.05};
+    double maximum_fpr{0.05};
 
     /*!\brief Allow a higher FPR in non-accuracy-critical parts of the HIBF structure.
      *
-     * Some parts in the hierarchical structure are not critical to ensure the seqan::hibf::config::maximum_false_positive_rate.
-     * These can be allowed to have a higher FPR to reduce the overall space consumption taking into account a small
-     * decrease in runtime performance.
+     * Some parts in the hierarchical structure are not critical to ensure the seqan::hibf::config::maximum_fpr.
+     * These can be allowed to have a higher FPR to reduce the overall space consumption, while only minimally
+     * affecting the runtime performance.
      *
-     * Value must be in range [0,1].
-     * Value must be equal to or larger than seqan::hibf::config::maximum_false_positive_rate.
+     * Value must be in range (0.0,1.0).
+     * Value must be equal to or larger than seqan::hibf::config::maximum_fpr.
      * Recommendation: default value (0.3)
      *
      * ### Technical details
-     * 
+     *
      * Merged bins in an HIBF layout will always be followed by one or more lower-level IBFs that will have split bins
      * or single bins (split = 1) to recover the original user bins. Thus, the FPR of merged bins does not determine the
-     * seqan::hibf::config::maximum_false_positive_rate, but is independent. Choosing a higher FPR for merged bins can
+     * seqan::hibf::config::maximum_fpr, but is independent. Choosing a higher FPR for merged bins can
      * lower the memory requirement but increases the runtime. Experiments show that the decrease in memory is
      * significant, while the runtime suffers only slightly. The accuracy of the results is not affected by this
      * parameter.
      *
      * Note: For each IBF there is a limit to how high the FPR of merged bins can be. Specifically, the FPR for merged
      * bins can never decrease the IBF size more than what is needed to ensure the
-     * seqan::hibf::config::maximum_false_positive_rate for split bins. This means that, at some point, choosing even
+     * seqan::hibf::config::maximum_fpr for split bins. This means that, at some point, choosing even
      * higher values for this parameter will have no effect anymore.
      *
      * \sa [Bloom Filter Calculator](https://hur.st/bloomfilter/).
@@ -293,10 +293,10 @@ struct config
      *
      * Constrains:
      *   * seqan::hibf::config::number_of_hash_functions must be in `[1,5]`.
-     *   * seqan::hibf::config::maximum_false_positive_rate must be in `(0.0,1.0)`.
-     *   * seqan::hibf::config::relaxed_fpr must be in `[0.0,1.0]`.
+     *   * seqan::hibf::config::maximum_fpr must be in `(0.0,1.0)`.
+     *   * seqan::hibf::config::relaxed_fpr must be in `(0.0,1.0)`.
      *   * seqan::hibf::config::relaxed_fpr must be equal to or larger than
-     *     seqan::hibf::config::maximum_false_positive_rate.
+     *     seqan::hibf::config::maximum_fpr.
      *   * seqan::hibf::config::threads must be greater than `0`.
      *   * seqan::hibf::config::sketch_bits must be in `[5,32]`.
      *   * seqan::hibf::config::tmax must be at most `18446744073709551552`.
@@ -323,7 +323,7 @@ private:
 
         archive(CEREAL_NVP(number_of_user_bins));
         archive(CEREAL_NVP(number_of_hash_functions));
-        archive(CEREAL_NVP(maximum_false_positive_rate));
+        archive(CEREAL_NVP(maximum_fpr));
         archive(CEREAL_NVP(relaxed_fpr));
         archive(CEREAL_NVP(threads));
 

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -161,7 +161,7 @@ public:
      *
      * Options recommended to adapt to your setup:
      * * `threads` - Choose number of threads depending on your hardware settings to speed up construction
-     * * `maximum_false_positive_rate` - How many false positive answers can you tolerate? A low FPR (e.g. 0.001) is
+     * * `maximum_fpr` - How many false positive answers can you tolerate? A low FPR (e.g. 0.001) is
      *   needed if you can tolerate a high RAM peak when using the HIBF but post-processing steps are heavy and FPs
      *   should be avoided. A high FPR (e.g. `0.3`) can be chosed if you want a very small HIBF and false positive
      *   can be easily filtered in the down-stream analysis

--- a/include/hibf/layout/graph.hpp
+++ b/include/hibf/layout/graph.hpp
@@ -48,6 +48,11 @@ struct graph
         std::optional<size_t> favourite_child_idx{std::nullopt};
         std::vector<layout::layout::user_bin> remaining_records{}; // non-merged bins (either split or single)
 
+        bool max_bin_is_merged() const
+        {
+            return favourite_child_idx.has_value();
+        }
+
         // Doesn't work, because the type is incomplete. To compare node, a comparison for the children member is needed.
         // But children is a std::vector<node>, so a comparison for node is needed to compare children.
         // https://godbolt.org/z/arrr4YKae

--- a/include/hibf/layout/hierarchical_binning.hpp
+++ b/include/hibf/layout/hierarchical_binning.hpp
@@ -78,13 +78,14 @@ private:
             if (max_id == max_split_id) // Overall max bin is a split bin.
                 return max_id;
 
-            // the minimum size of the TBs of this IBF to ensure the maximum_false_positive_rate for split bins
-            size_t const minimum_bits{build::bin_size_in_bits({.fpr = config.maximum_false_positive_rate,
+            // Split cardinality `max_split_size` already accounts for fpr correction.
+            // The minimum size of the TBs of this IBF to ensure the maximum_false_positive_rate for split bins.
+            size_t const minimum_bits{build::bin_size_in_bits({.fpr = config.maximum_fpr,
                                                                .hash_count = config.number_of_hash_functions,
                                                                .elements = max_split_size})};
 
-            // the potential size of the TBs of this IBF given the allowed merged bin FPR
-            size_t const merged_bits{build::bin_size_in_bits({.fpr = config.relaxed_fpr,
+            // The potential size of the TBs of this IBF given the allowed merged bin FPR.
+            size_t const merged_bits{build::bin_size_in_bits({.fpr = config.relaxed_fpr, //
                                                               .hash_count = config.number_of_hash_functions,
                                                               .elements = max_size})};
 

--- a/src/build/construct_ibf.cpp
+++ b/src/build/construct_ibf.cpp
@@ -32,8 +32,7 @@ seqan::hibf::interleaved_bloom_filter construct_ibf(robin_hood::unordered_flat_s
     assert(!max_bin_is_merged || number_of_bins == 1u); // merged max bin implies (=>) number of bins == 1
 
     size_t const kmers_per_bin{(kmers.size() + number_of_bins - 1u) / number_of_bins}; // Integer ceil
-    double const fpr = max_bin_is_merged ? data.config.relaxed_fpr
-                                         : data.config.maximum_false_positive_rate;
+    double const fpr = max_bin_is_merged ? data.config.relaxed_fpr : data.config.maximum_fpr;
 
     size_t const bin_bits{bin_size_in_bits({.fpr = fpr, //
                                             .hash_count = data.config.number_of_hash_functions,

--- a/src/build/construct_ibf.cpp
+++ b/src/build/construct_ibf.cpp
@@ -28,7 +28,7 @@ seqan::hibf::interleaved_bloom_filter construct_ibf(robin_hood::unordered_flat_s
                                                     build_data & data,
                                                     bool is_root)
 {
-    bool const max_bin_is_merged = ibf_node.favourite_child_idx.has_value();
+    bool const max_bin_is_merged = ibf_node.max_bin_is_merged();
     assert(!max_bin_is_merged || number_of_bins == 1u); // merged max bin implies (=>) number of bins == 1
 
     size_t const kmers_per_bin{(kmers.size() + number_of_bins - 1u) / number_of_bins}; // Integer ceil

--- a/src/build/construct_ibf.cpp
+++ b/src/build/construct_ibf.cpp
@@ -28,12 +28,21 @@ seqan::hibf::interleaved_bloom_filter construct_ibf(robin_hood::unordered_flat_s
                                                     build_data & data,
                                                     bool is_root)
 {
-    size_t const kmers_per_bin{static_cast<size_t>(std::ceil(static_cast<double>(kmers.size()) / number_of_bins))};
-    double const bin_bits{static_cast<double>(bin_size_in_bits({.fpr = data.config.maximum_false_positive_rate,
-                                                                .hash_count = data.config.number_of_hash_functions,
-                                                                .elements = kmers_per_bin}))};
+    bool const max_bin_is_merged = ibf_node.favourite_child_idx.has_value();
+    assert(!max_bin_is_merged || number_of_bins == 1u); // merged max bin implies (=>) number of bins == 1
+
+    size_t const kmers_per_bin{(kmers.size() + number_of_bins - 1u) / number_of_bins}; // Integer ceil
+    double const fpr = max_bin_is_merged ? data.config.relaxed_fpr
+                                         : data.config.maximum_false_positive_rate;
+
+    size_t const bin_bits{bin_size_in_bits({.fpr = fpr, //
+                                            .hash_count = data.config.number_of_hash_functions,
+                                            .elements = kmers_per_bin})};
+    // data.fpr_correction[1] == 1.0, but we can avoid floating point operations with the ternary.
+    // Check number_of_bins instead of max_bin_is_merged, because split bins can also occupy only one technical bin.
     seqan::hibf::bin_size const bin_size{
-        static_cast<size_t>(std::ceil(bin_bits * data.fpr_correction[number_of_bins]))};
+        number_of_bins == 1u ? bin_bits
+                             : static_cast<size_t>(std::ceil(bin_bits * data.fpr_correction[number_of_bins]))};
     seqan::hibf::bin_count const bin_count{ibf_node.number_of_technical_bins};
 
     timer<concurrent::no> local_index_allocation_timer{};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -75,6 +75,14 @@ void config::validate_and_set_defaults()
     if (maximum_false_positive_rate <= 0.0 || maximum_false_positive_rate >= 1.0)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::maximum_false_positive_rate must be in (0.0,1.0)."};
 
+    if (relaxed_fpr <= 0.0 || relaxed_fpr >= 1.0)
+        throw std::invalid_argument{
+            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in (0.0,1.0)."};
+
+    if (relaxed_fpr < maximum_false_positive_rate)
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] config::relaxed_fpr must be "
+                                    "greater than or equal to config::maximum_false_positive_rate."};
+
     if (threads == 0u)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::threads must be greater than 0."};
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -72,16 +72,15 @@ void config::validate_and_set_defaults()
     if (number_of_hash_functions == 0u || number_of_hash_functions > 5u)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::number_of_hash_functions must be in [1,5]."};
 
-    if (maximum_false_positive_rate <= 0.0 || maximum_false_positive_rate >= 1.0)
-        throw std::invalid_argument{"[HIBF CONFIG ERROR] config::maximum_false_positive_rate must be in (0.0,1.0)."};
+    if (maximum_fpr <= 0.0 || maximum_fpr >= 1.0)
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] config::maximum_fpr must be in (0.0,1.0)."};
 
     if (relaxed_fpr <= 0.0 || relaxed_fpr >= 1.0)
-        throw std::invalid_argument{
-            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in (0.0,1.0)."};
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] config::relaxed_fpr must be in (0.0,1.0)."};
 
-    if (relaxed_fpr < maximum_false_positive_rate)
+    if (relaxed_fpr < maximum_fpr)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::relaxed_fpr must be "
-                                    "greater than or equal to config::maximum_false_positive_rate."};
+                                    "greater than or equal to config::maximum_fpr."};
 
     if (threads == 0u)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::threads must be greater than 0."};

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -182,8 +182,9 @@ void build_index(hierarchical_interleaved_bloom_filter & hibf,
     layout::graph::node const & root_node = data.ibf_graph.root;
 
     size_t const t_max{root_node.number_of_technical_bins};
-    data.fpr_correction = layout::compute_fpr_correction(
-        {.fpr = config.maximum_false_positive_rate, .hash_count = config.number_of_hash_functions, .t_max = t_max});
+    data.fpr_correction = layout::compute_fpr_correction({.fpr = config.maximum_fpr, //
+                                                          .hash_count = config.number_of_hash_functions,
+                                                          .t_max = t_max});
 
     hierarchical_build(hibf, root_node, data);
 

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -47,7 +47,7 @@ size_t hierarchical_build(hierarchical_interleaved_bloom_filter & hibf,
 
     auto initialise_max_bin_kmers = [&]() -> size_t
     {
-        if (current_node.favourite_child_idx.has_value()) // max bin is a merged bin
+        if (current_node.max_bin_is_merged())
         {
             // recursively initialize favourite child first
             ibf_positions[current_node.max_bin_index] =
@@ -91,7 +91,7 @@ size_t hierarchical_build(hierarchical_interleaved_bloom_filter & hibf,
 
         // We do not want to process the favourite child. It has already been processed prior.
         // https://godbolt.org/z/6Yav7hrG1
-        if (current_node.favourite_child_idx.has_value())
+        if (current_node.max_bin_is_merged())
             std::erase(indices, current_node.favourite_child_idx.value());
 
         if (is_root)
@@ -127,7 +127,7 @@ size_t hierarchical_build(hierarchical_interleaved_bloom_filter & hibf,
     loop_over_children();
 
     // If max bin was a merged bin, process all remaining records, otherwise the first one has already been processed
-    size_t const start{(current_node.favourite_child_idx.has_value()) ? 0u : 1u};
+    size_t const start{(current_node.max_bin_is_merged()) ? 0u : 1u};
     for (size_t i = start; i < current_node.remaining_records.size(); ++i)
     {
         auto const & record = current_node.remaining_records[i];

--- a/src/interleaved_bloom_filter.cpp
+++ b/src/interleaved_bloom_filter.cpp
@@ -59,7 +59,7 @@ size_t max_bin_size(config & configuration)
         max_size = std::max(max_size, kmers.size());
     }
 
-    return build::bin_size_in_bits({.fpr = configuration.maximum_false_positive_rate,
+    return build::bin_size_in_bits({.fpr = configuration.maximum_fpr, //
                                     .hash_count = configuration.number_of_hash_functions,
                                     .elements = max_size});
 }

--- a/src/layout/compute_layout.cpp
+++ b/src/layout/compute_layout.cpp
@@ -31,11 +31,11 @@ layout compute_layout(config const & config,
     std::stringstream output_buffer;
     std::stringstream header_buffer;
 
-    data_store store{.false_positive_rate = config.maximum_false_positive_rate,
+    data_store store{.false_positive_rate = config.maximum_fpr,
                      .hibf_layout = &resulting_layout,
                      .kmer_counts = std::addressof(kmer_counts),
                      .sketches = std::addressof(sketches)};
-    store.fpr_correction = compute_fpr_correction({.fpr = config.maximum_false_positive_rate,
+    store.fpr_correction = compute_fpr_correction({.fpr = config.maximum_fpr, //
                                                    .hash_count = config.number_of_hash_functions,
                                                    .t_max = config.tmax});
 

--- a/test/performance/hibf/hierarchical_interleaved_bloom_filter_benchmark.cpp
+++ b/test/performance/hibf/hierarchical_interleaved_bloom_filter_benchmark.cpp
@@ -59,7 +59,7 @@ auto set_up(::benchmark::State const & state)
     seqan::hibf::config config{.input_fn = distribute_hashes_across_ub,
                                .number_of_user_bins = num_ub,
                                .number_of_hash_functions = hash_num,
-                               .maximum_false_positive_rate = fpr,
+                               .maximum_fpr = fpr,
                                .threads = 4u, // Only applies to layout and build
                                .disable_estimate_union = true};
 

--- a/test/snippet/hibf/hibf_construction.cpp
+++ b/test/snippet/hibf/hibf_construction.cpp
@@ -24,8 +24,8 @@ int main()
     seqan::hibf::config config{.input_fn = my_input,     // required
                                .number_of_user_bins = 2, // required
                                .number_of_hash_functions = 2,
-                               .maximum_false_positive_rate = 0.05, // recommended to adapt
-                               .threads = 1,                        // recommended to adapt
+                               .maximum_fpr = 0.05, // recommended to adapt
+                               .threads = 1,        // recommended to adapt
                                .sketch_bits = 12,
                                .tmax = 0, // triggers default copmutation
                                .alpha = 1.2,

--- a/test/snippet/readme.cpp
+++ b/test/snippet/readme.cpp
@@ -52,7 +52,7 @@ int main()
     seqan::hibf::config config{.input_fn = get_user_bin_data, // required
                                .number_of_user_bins = 3u,     // required
                                .number_of_hash_functions = 2u,
-                               .maximum_false_positive_rate = 0.05,
+                               .maximum_fpr = 0.05,
                                .threads = 1u};
 
     // The HIBF constructor will determine a hierarchical layout for the user bins and build the filter.

--- a/test/unit/hibf/config_test.cpp
+++ b/test/unit/hibf/config_test.cpp
@@ -39,6 +39,7 @@ TEST(config_test, write_to)
                                     "@        \"number_of_user_bins\": 123456789,\n"
                                     "@        \"number_of_hash_functions\": 4,\n"
                                     "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                                    "@        \"relaxed_fpr\": 0.3,\n"
                                     "@        \"threads\": 31,\n"
                                     "@        \"sketch_bits\": 8,\n"
                                     "@        \"tmax\": 128,\n"
@@ -62,6 +63,7 @@ TEST(config_test, read_from)
                          "@        \"number_of_user_bins\": 123456789,\n"
                          "@        \"number_of_hash_functions\": 4,\n"
                          "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                         "@        \"relaxed_fpr\": 0.3,\n"
                          "@        \"threads\": 31,\n"
                          "@        \"sketch_bits\": 8,\n"
                          "@        \"tmax\": 128,\n"
@@ -79,6 +81,7 @@ TEST(config_test, read_from)
     EXPECT_EQ(configuration.number_of_user_bins, 123456789);
     EXPECT_EQ(configuration.number_of_hash_functions, 4);
     EXPECT_EQ(configuration.maximum_false_positive_rate, 0.0001);
+    EXPECT_EQ(configuration.relaxed_fpr, 0.3);
     EXPECT_EQ(configuration.threads, 31);
     EXPECT_EQ(configuration.sketch_bits, 8);
     EXPECT_EQ(configuration.tmax, 128);
@@ -102,6 +105,7 @@ TEST(config_test, read_from_with_more_meta)
                          "@        \"number_of_user_bins\": 123456789,\n"
                          "@        \"number_of_hash_functions\": 4,\n"
                          "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                         "@        \"relaxed_fpr\": 0.3,\n"
                          "@        \"threads\": 31,\n"
                          "@        \"sketch_bits\": 8,\n"
                          "@        \"tmax\": 128,\n"
@@ -119,6 +123,7 @@ TEST(config_test, read_from_with_more_meta)
     EXPECT_EQ(configuration.number_of_user_bins, 123456789);
     EXPECT_EQ(configuration.number_of_hash_functions, 4);
     EXPECT_EQ(configuration.maximum_false_positive_rate, 0.0001);
+    EXPECT_EQ(configuration.relaxed_fpr, 0.3);
     EXPECT_EQ(configuration.threads, 31);
     EXPECT_EQ(configuration.sketch_bits, 8);
     EXPECT_EQ(configuration.tmax, 128);
@@ -184,6 +189,30 @@ TEST(config_test, validate_and_set_defaults)
         configuration.maximum_false_positive_rate = 1.0;
         check_error_message(configuration,
                             "[HIBF CONFIG ERROR] config::maximum_false_positive_rate must be in (0.0,1.0).");
+    }
+
+    // relaxed_fpr must be in (0.0,1.0)
+    {
+        seqan::hibf::config configuration{.input_fn = dummy_input_fn,
+                                          .number_of_user_bins = 1u,
+                                          .relaxed_fpr = -0.1};
+        check_error_message(configuration,
+                            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in [0.0,1.0].");
+
+        configuration.relaxed_fpr = 1.1;
+        check_error_message(configuration,
+                            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in [0.0,1.0].");
+    }
+
+    // relaxed_fpr must equal to or greater than maximum_false_positive_rate
+    {
+        seqan::hibf::config configuration{.input_fn = dummy_input_fn,
+                                          .number_of_user_bins = 1u,
+                                          .maximum_false_positive_rate = 0.3,
+                                          .relaxed_fpr = 0.2};
+        check_error_message(configuration,
+                            "[HIBF CONFIG ERROR] config::relaxed_fpr must be "
+                            "greater than or equal to config::maximum_false_positive_rate.");
     }
 
     // threads cannot be 0

--- a/test/unit/hibf/config_test.cpp
+++ b/test/unit/hibf/config_test.cpp
@@ -21,7 +21,7 @@ TEST(config_test, write_to)
 
     configuration.number_of_user_bins = 123456789;
     configuration.number_of_hash_functions = 4;
-    configuration.maximum_false_positive_rate = 0.0001;
+    configuration.maximum_fpr = 0.0001;
     configuration.threads = 31;
     configuration.sketch_bits = 8;
     configuration.tmax = 128;
@@ -38,7 +38,7 @@ TEST(config_test, write_to)
                                     "@        \"version\": 1,\n"
                                     "@        \"number_of_user_bins\": 123456789,\n"
                                     "@        \"number_of_hash_functions\": 4,\n"
-                                    "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                                    "@        \"maximum_fpr\": 0.0001,\n"
                                     "@        \"relaxed_fpr\": 0.3,\n"
                                     "@        \"threads\": 31,\n"
                                     "@        \"sketch_bits\": 8,\n"
@@ -62,7 +62,7 @@ TEST(config_test, read_from)
                          "@        \"version\": 1,\n"
                          "@        \"number_of_user_bins\": 123456789,\n"
                          "@        \"number_of_hash_functions\": 4,\n"
-                         "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                         "@        \"maximum_fpr\": 0.0001,\n"
                          "@        \"relaxed_fpr\": 0.3,\n"
                          "@        \"threads\": 31,\n"
                          "@        \"sketch_bits\": 8,\n"
@@ -80,7 +80,7 @@ TEST(config_test, read_from)
 
     EXPECT_EQ(configuration.number_of_user_bins, 123456789);
     EXPECT_EQ(configuration.number_of_hash_functions, 4);
-    EXPECT_EQ(configuration.maximum_false_positive_rate, 0.0001);
+    EXPECT_EQ(configuration.maximum_fpr, 0.0001);
     EXPECT_EQ(configuration.relaxed_fpr, 0.3);
     EXPECT_EQ(configuration.threads, 31);
     EXPECT_EQ(configuration.sketch_bits, 8);
@@ -104,7 +104,7 @@ TEST(config_test, read_from_with_more_meta)
                          "@        \"version\": 1,\n"
                          "@        \"number_of_user_bins\": 123456789,\n"
                          "@        \"number_of_hash_functions\": 4,\n"
-                         "@        \"maximum_false_positive_rate\": 0.0001,\n"
+                         "@        \"maximum_fpr\": 0.0001,\n"
                          "@        \"relaxed_fpr\": 0.3,\n"
                          "@        \"threads\": 31,\n"
                          "@        \"sketch_bits\": 8,\n"
@@ -122,7 +122,7 @@ TEST(config_test, read_from_with_more_meta)
 
     EXPECT_EQ(configuration.number_of_user_bins, 123456789);
     EXPECT_EQ(configuration.number_of_hash_functions, 4);
-    EXPECT_EQ(configuration.maximum_false_positive_rate, 0.0001);
+    EXPECT_EQ(configuration.maximum_fpr, 0.0001);
     EXPECT_EQ(configuration.relaxed_fpr, 0.3);
     EXPECT_EQ(configuration.threads, 31);
     EXPECT_EQ(configuration.sketch_bits, 8);
@@ -178,41 +178,33 @@ TEST(config_test, validate_and_set_defaults)
         check_error_message(configuration, "[HIBF CONFIG ERROR] config::number_of_hash_functions must be in [1,5].");
     }
 
-    // maximum_false_positive_rate must be in (0.0,1.0)
+    // maximum_fpr must be in (0.0,1.0)
     {
-        seqan::hibf::config configuration{.input_fn = dummy_input_fn,
-                                          .number_of_user_bins = 1u,
-                                          .maximum_false_positive_rate = 0.0};
-        check_error_message(configuration,
-                            "[HIBF CONFIG ERROR] config::maximum_false_positive_rate must be in (0.0,1.0).");
+        seqan::hibf::config configuration{.input_fn = dummy_input_fn, .number_of_user_bins = 1u, .maximum_fpr = 0.0};
+        check_error_message(configuration, "[HIBF CONFIG ERROR] config::maximum_fpr must be in (0.0,1.0).");
 
-        configuration.maximum_false_positive_rate = 1.0;
-        check_error_message(configuration,
-                            "[HIBF CONFIG ERROR] config::maximum_false_positive_rate must be in (0.0,1.0).");
+        configuration.maximum_fpr = 1.0;
+        check_error_message(configuration, "[HIBF CONFIG ERROR] config::maximum_fpr must be in (0.0,1.0).");
     }
 
     // relaxed_fpr must be in (0.0,1.0)
     {
-        seqan::hibf::config configuration{.input_fn = dummy_input_fn,
-                                          .number_of_user_bins = 1u,
-                                          .relaxed_fpr = -0.1};
-        check_error_message(configuration,
-                            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in [0.0,1.0].");
+        seqan::hibf::config configuration{.input_fn = dummy_input_fn, .number_of_user_bins = 1u, .relaxed_fpr = 0.0};
+        check_error_message(configuration, "[HIBF CONFIG ERROR] config::relaxed_fpr must be in (0.0,1.0).");
 
-        configuration.relaxed_fpr = 1.1;
-        check_error_message(configuration,
-                            "[HIBF CONFIG ERROR] config::relaxed_fpr must be in [0.0,1.0].");
+        configuration.relaxed_fpr = 1.0;
+        check_error_message(configuration, "[HIBF CONFIG ERROR] config::relaxed_fpr must be in (0.0,1.0).");
     }
 
-    // relaxed_fpr must equal to or greater than maximum_false_positive_rate
+    // relaxed_fpr must equal to or greater than maximum_fpr
     {
         seqan::hibf::config configuration{.input_fn = dummy_input_fn,
                                           .number_of_user_bins = 1u,
-                                          .maximum_false_positive_rate = 0.3,
+                                          .maximum_fpr = 0.3,
                                           .relaxed_fpr = 0.2};
         check_error_message(configuration,
                             "[HIBF CONFIG ERROR] config::relaxed_fpr must be "
-                            "greater than or equal to config::maximum_false_positive_rate.");
+                            "greater than or equal to config::maximum_fpr.");
     }
 
     // threads cannot be 0

--- a/test/unit/hibf/hierarchical_interleaved_bloom_filter_test.cpp
+++ b/test/unit/hibf/hierarchical_interleaved_bloom_filter_test.cpp
@@ -56,6 +56,7 @@ TEST(hibf_test, build_from_layout)
                              "@        \"number_of_user_bins\": 2,\n"
                              "@        \"number_of_hash_functions\": 2,\n"
                              "@        \"maximum_false_positive_rate\": 0.05,\n"
+                             "@        \"relaxed_fpr\": 0.3,\n"
                              "@        \"threads\": 1,\n"
                              "@        \"sketch_bits\": 12,\n"
                              "@        \"tmax\": 64,\n"

--- a/test/unit/hibf/hierarchical_interleaved_bloom_filter_test.cpp
+++ b/test/unit/hibf/hierarchical_interleaved_bloom_filter_test.cpp
@@ -55,7 +55,7 @@ TEST(hibf_test, build_from_layout)
                              "@        \"version\": 1,\n"
                              "@        \"number_of_user_bins\": 2,\n"
                              "@        \"number_of_hash_functions\": 2,\n"
-                             "@        \"maximum_false_positive_rate\": 0.05,\n"
+                             "@        \"maximum_fpr\": 0.05,\n"
                              "@        \"relaxed_fpr\": 0.3,\n"
                              "@        \"threads\": 1,\n"
                              "@        \"sketch_bits\": 12,\n"
@@ -104,7 +104,7 @@ TEST(hibf_test, three_level_hibf)
                                        it = i;
                                },
                                .number_of_user_bins = 4097,
-                               .maximum_false_positive_rate = 0.001,
+                               .maximum_fpr = 0.001,
                                .threads = 4,
                                .tmax = 64,
                                .disable_estimate_union = true,
@@ -153,7 +153,7 @@ TEST(hibf_test, unevenly_sized_and_unique_user_bins)
                                        it = i;
                                },
                                .number_of_user_bins = 500,
-                               .maximum_false_positive_rate = 0.001,
+                               .maximum_fpr = 0.001,
                                .threads = 4,
                                .tmax = 64,
                                .disable_estimate_union = true,
@@ -187,7 +187,7 @@ TEST(hibf_test, evenly_sized_and_highly_similar_user_bins)
                                        it = i;
                                },
                                .number_of_user_bins = 1000,
-                               .maximum_false_positive_rate = 0.001,
+                               .maximum_fpr = 0.001,
                                .threads = 4,
                                .tmax = 64,
                                .disable_estimate_union = true,

--- a/test/unit/hibf/layout/graph_test.cpp
+++ b/test/unit/hibf/layout/graph_test.cpp
@@ -11,7 +11,18 @@
 #include <hibf/layout/graph.hpp>  // for graph
 #include <hibf/layout/layout.hpp> // for layout
 
-TEST(layout_test, printing_max_bins)
+TEST(graph_node_test, function_max_bin_is_merged)
+{
+    seqan::hibf::layout::graph::node current_node{};
+
+    EXPECT_FALSE(current_node.max_bin_is_merged());
+
+    current_node.favourite_child_idx = 0;
+
+    EXPECT_TRUE(current_node.max_bin_is_merged());
+}
+
+TEST(graph_test, construction_from_layout)
 {
     // prepare layout
     seqan::hibf::layout::layout hibf_layout;

--- a/test/unit/hibf/layout/hierarchical_binning_test.cpp
+++ b/test/unit/hibf/layout/hierarchical_binning_test.cpp
@@ -28,7 +28,7 @@ TEST(hierarchical_binning_test, small_example)
     data.fpr_correction =
         seqan::hibf::layout::compute_fpr_correction({.fpr = 0.05, .hash_count = 2, .t_max = config.tmax});
     seqan::hibf::layout::hierarchical_binning algo{data, config};
-    EXPECT_EQ(algo.execute(), 1u); // #HIGH_LEVEL_IBF max_bin_id:3
+    EXPECT_EQ(algo.execute(), 3u); // #HIGH_LEVEL_IBF max_bin_id:3
 
     std::vector<seqan::hibf::layout::layout::max_bin> expected_max_bins{{{1}, 22}, {{2}, 22}};
 


### PR DESCRIPTION
TODO

- [ ] decide on a plausible default for the allowed max merged bin FPR

Some numbers:

Fall all HIBFs below `h=2`, `k=32`, `tmax=192` timed on augustus 
Query time is the fastest run out of 3 runs in total.

| max-FPR | max-merged-bin-FR | Build Time | Index size | Query time 10Mio reads |
|--------:|------------------:|-----------:|-----------:|-----------------------:|
| 0.05    |              0.05 |      17:00 |   170.66G  |                   3:09 |
| 0.05    |              0.3  |      15:52 |   143.50G  |                   2:51 | 
| 0.05    |              0.5  |      15:56 |   139.00G  |                   3:18 |                

Accuracy seems 2% worse than without a higher max bin FPR

Raptor detailed output:


<details><summary>m-fpr 0.05 - build</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 1020.11
  Peak memory usage [GiB]: 265.5
  Index allocation [s]: 59.88
  User bin I/O avg per thread [s]: 246.43
  User bin I/O sum [s]: 12321.72
  Merge kmer sets avg per thread [s]: 84.36
  Merge kmer sets sum [s]: 4217.88
  Fill IBF avg per thread [s]: 156.47
  Fill IBF sum [s]: 7823.72
  Store index [s]: 149.39
  ```
  
</details>

<details><summary>m-fpr 0.3 - build</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 952.15
  Peak memory usage [GiB]: 234.8
  Index allocation [s]: 48.37
  User bin I/O avg per thread [s]: 236.99
  User bin I/O sum [s]: 11849.43
  Merge kmer sets avg per thread [s]: 84.15
  Merge kmer sets sum [s]: 4207.48
  Fill IBF avg per thread [s]: 149.78
  Fill IBF sum [s]: 7489.20
  Store index [s]: 125.08
  ```
  
</details>

<details><summary>m-fpr 0.5 - build</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 956.00
  Peak memory usage [GiB]: 230.9
  Index allocation [s]: 47.52
  User bin I/O avg per thread [s]: 237.18
  User bin I/O sum [s]: 11858.87
  Merge kmer sets avg per thread [s]: 84.49
  Merge kmer sets sum [s]: 4224.39
  Fill IBF avg per thread [s]: 151.83
  Fill IBF sum [s]: 7591.71
  Store index [s]: 134.99
  ```
  
</details>

<details><summary>m-fpr 0.05 - query</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 189.11
  Peak memory usage [GiB]: 170.7
  Determine query length [s]: 21.10
  Query file I/O [s]: 19.19
  Load index [s]: 70.73
  Compute minimiser [s]: 2.64
  Query IBF [s]: 74.71
  Generate results [s]: 2.82
  ```
  
</details>

<details><summary>m-fpr 0.3 - query</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 183.07
  Peak memory usage [GiB]: 143.5
  Determine query length [s]: 20.99
  Query file I/O [s]: 19.22
  Load index [s]: 54.02
  Compute minimiser [s]: 2.63
  Query IBF [s]: 81.53
  Generate results [s]: 2.57
  ```
  
</details>

<details><summary>m-fpr 0.5 - query</summary>

  ```
  ============= Timings =============
  Wall clock time [s]: 198.76
  Peak memory usage [GiB]: 139.0
  Determine query length [s]: 20.25
  Query file I/O [s]: 16.98
  Load index [s]: 59.53
  Compute minimiser [s]: 2.61
  Query IBF [s]: 99.32
  Generate results [s]: 2.54
  ```
  
</details>