### PR TITLE
[FEATURE] Unitialised resize for deserialisation

### DIFF
--- a/include/hibf/cereal/concepts.hpp
+++ b/include/hibf/cereal/concepts.hpp
@@ -7,6 +7,7 @@
 #include <hibf/platform.hpp>
 
 #include <cereal/details/helpers.hpp> // for InputArchiveBase, OutputArchiveBase
+#include <cereal/details/traits.hpp>  // for InputArchiveBase, OutputArchiveBase
 
 namespace seqan::hibf
 {
@@ -19,5 +20,8 @@ concept cereal_input_archive = std::is_base_of_v<cereal::detail::InputArchiveBas
 
 template <typename t>
 concept cereal_archive = cereal_output_archive<t> || cereal_input_archive<t>;
+
+template <typename t>
+concept cereal_text_archive = std::is_base_of_v<cereal::traits::TextArchive, t>;
 
 } // namespace seqan::hibf

--- a/include/hibf/hierarchical_interleaved_bloom_filter.hpp
+++ b/include/hibf/hierarchical_interleaved_bloom_filter.hpp
@@ -22,6 +22,7 @@
 #include <hibf/platform.hpp>                 // for HIBF_CONSTEXPR_VECTOR
 
 #include <cereal/macros.hpp> // for CEREAL_SERIALIZE_FUNCTION_NAME
+#include <cereal/types/vector.hpp>
 
 namespace seqan::hibf
 {

--- a/test/documentation/hibf_doxygen_cfg.in
+++ b/test/documentation/hibf_doxygen_cfg.in
@@ -340,6 +340,9 @@ SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = ${HIBF_DOXYGEN_SOURCE_DIR}/include
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = "HIBF_DOXYGEN_ONLY(x)= x" \
+                         CEREAL_SERIALIZE_FUNCTION_NAME=serialize \
+                         CEREAL_LOAD_FUNCTION_NAME=load \
+                         CEREAL_SAVE_FUNCTION_NAME=save \
                          ${HIBF_DOXYGEN_PREDEFINED_NDEBUG} \
                          HIBF_CONSTEXPR_VECTOR=constexpr
 EXPAND_AS_DEFINED      =

--- a/test/performance/ibf/CMakeLists.txt
+++ b/test/performance/ibf/CMakeLists.txt
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 hibf_benchmark (bit_vector_benchmark.cpp)
+hibf_benchmark (bit_vector_serialisation_benchmark.cpp)
 hibf_benchmark (interleaved_bloom_filter_benchmark.cpp)

--- a/test/performance/ibf/bit_vector_serialisation_benchmark.cpp
+++ b/test/performance/ibf/bit_vector_serialisation_benchmark.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2006-2023, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <benchmark/benchmark.h> // for Benchmark, State, BENCHMARK_CAPTURE, DoNotOptimize, BENCHMARK_MAIN
+
+#include <algorithm> // for __generate_fn, generate
+#include <cinttypes> // for int32_t, uint8_t
+#include <cstddef>   // for size_t
+#include <filesystem>
+#include <fstream>
+#include <memory>      // for allocator
+#include <random>      // for uniform_int_distribution, mt19937_64
+#include <type_traits> // for invoke_result_t
+#include <utility>     // for move, pair
+
+#include <hibf/misc/bit_vector.hpp>     // for bit_vector
+#include <hibf/test/sandboxed_path.hpp> // for sandboxed_path, operator/
+#include <hibf/test/tmp_directory.hpp>  // for tmp_directory
+
+#include <cereal/archives/binary.hpp> // for BinaryInputArchive, BinaryOutputArchive
+
+seqan::hibf::bit_vector generate_bit_vector(size_t const size_in_bits, size_t const seed = 0u)
+{
+    std::mt19937_64 engine{seed};
+    std::uniform_int_distribution<uint8_t> dist{0u, 1u};
+
+    auto gen = [&dist, &engine]()
+    {
+        return dist(engine);
+    };
+    seqan::hibf::bit_vector vec(size_in_bits);
+    std::ranges::generate(vec, gen);
+
+    return vec;
+}
+
+static seqan::hibf::test::tmp_directory tmp{};
+
+void load_bit_vector(benchmark::State & state)
+{
+    size_t const size_in_bits = 1ULL << state.range(0);
+    auto const filename = tmp.path() / std::to_string(state.range(0));
+
+    if (!std::filesystem::exists(filename))
+    {
+        seqan::hibf::bit_vector const vector = generate_bit_vector(size_in_bits);
+
+        std::ofstream output_stream{filename, std::ios::binary};
+        cereal::BinaryOutputArchive oarchive{output_stream};
+        oarchive(vector);
+    }
+
+    // Substract 8 bytes for serialised size_ member.
+    size_t const filesize_in_bytes = std::filesystem::file_size(filename) - 8u;
+
+    if (size_in_bits / 8u != filesize_in_bytes)
+        throw std::logic_error{"Actual and expected file size differ."};
+
+    for (auto _ : state)
+    {
+        seqan::hibf::bit_vector vector{};
+        {
+            std::ifstream input_stream{filename, std::ios::binary};
+            cereal::BinaryInputArchive iarchive{input_stream};
+            iarchive(vector);
+        }
+        benchmark::DoNotOptimize(vector);
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(state.iterations()) * filesize_in_bytes);
+    // Use `filesize_in_bytes` to make benchmark show `1Mi` instead of `1.00001Mi`.
+    state.counters["filesize"] =
+        benchmark::Counter(filesize_in_bytes, benchmark::Counter::kDefaults, benchmark::Counter::OneK::kIs1024);
+}
+
+// Benchmark ranges are `int32_t`, i.e to small to represent 4 GiB or more.
+// Hence we use `2^x`.
+// 13 -> 1KiB
+// 23 -> 1MiB
+// 33 -> 1GiB
+// We use a small number here for the unit tests.
+// Sizes of 10s of GiB would be more interesting for actual benchmarking.
+static constexpr int32_t min_range = 13;
+static constexpr int32_t max_range = 13;
+
+BENCHMARK(load_bit_vector)->Range(min_range, max_range);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
I ran some benchmarks with raptor.

* `uninit` = with PR
* `init` = without PR
* all times in seconds

### Index size: 135.5 GiB (left) and 363.2 GiB (right)

| Iteration | uninit | init  | uninit | init  |
|-----------|--------|-------|--------|-------|
| 0         | 138.8  | 253.3 | 247.7  | 676.0 |
| 1         | 51.5   | 114.2 | 245.9  | 603.8 |
| 2         | 49.1   | 109.8 | 146.1  | 256.0 |
| 3         | 48.6   | 104.9 | 184.2  | 317.4 |
| 4         | 48.6   | 104.6 | 246.1  | 280.8 |
| 5         | 48.6   | 104.4 | 202.0  | 272.2 |
| 6         | 48.6   | 104.4 | 204.8  | 273.4 |
| 7         | 48.6   | 104.7 | 188.9  | 274.7 |
| 8         | 48.6   | 104.3 | 187.2  | 274.3 |
| 9         | 48.6   | 104.2 | 207.5  | 274.4 |
| Max       | 138.8  | 253.3 | 247.7  | 676.0 |
| Avg       | 58.0   | 120.9 | 206.0  | 350.3 |
| Max[2:9]  | 49.1   | 109.8 | 246.1  | 317.4 |
| Avg[2:9]  | 48.7   | 105.2 | 195.8  | 277.9 |