### PR TITLE
[TEST] HLL benchmark

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -72,7 +72,6 @@ jobs:
           mkdir build
           cd build
           cmake ../test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                                            -DHIBF_NATIVE_BUILD=OFF \
                                             -DHIBF_VERBOSE_TESTS=OFF
           make -j2 gtest_main
 

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -59,7 +59,6 @@ jobs:
             compiler: "intel"
             build: unit
             build_type: Release
-            cxx_flags: "-Xclang=-Wno-pass-failed"
 
     steps:
       - name: Checkout
@@ -85,7 +84,6 @@ jobs:
           mkdir build
           cd build
           cmake ../test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                                            -DHIBF_NATIVE_BUILD=OFF \
                                             -DHIBF_VERBOSE_TESTS=OFF \
                                             -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}"
           make -j2 gtest_main

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -77,7 +77,6 @@ jobs:
           mkdir build
           cd build
           cmake ../test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-                                            -DHIBF_NATIVE_BUILD=OFF \
                                             -DHIBF_VERBOSE_TESTS=OFF
           make -j3 gtest_main
 

--- a/.github/workflows/ci_misc.yml
+++ b/.github/workflows/ci_misc.yml
@@ -109,7 +109,6 @@ jobs:
           cd build
           cmake ../test/${{ matrix.build }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                                             -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" \
-                                            -DHIBF_NATIVE_BUILD=OFF \
                                             -DHIBF_VERBOSE_TESTS=OFF \
                                             -DHIBF_USE_INCLUDE_DEPENDENCIES="${{ matrix.use_include_dependencies }}"
           case "${{ matrix.build }}" in

--- a/.github/workflows/ci_util.yml
+++ b/.github/workflows/ci_util.yml
@@ -59,8 +59,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ../util -DCMAKE_BUILD_TYPE=Release \
-                        -DHIBF_NATIVE_BUILD=OFF
+          cmake ../util -DCMAKE_BUILD_TYPE=Release
 
       - name: Build util
         run: |

--- a/test/performance/sketch/CMakeLists.txt
+++ b/test/performance/sketch/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2006-2023, Knut Reinert & Freie Universität Berlin
+# SPDX-FileCopyrightText: 2016-2023, Knut Reinert & MPI für molekulare Genetik
+# SPDX-License-Identifier: BSD-3-Clause
+
+hibf_benchmark (hyperloglog_benchmark.cpp)

--- a/test/performance/sketch/hyperloglog_benchmark.cpp
+++ b/test/performance/sketch/hyperloglog_benchmark.cpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2006-2023, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2023, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <benchmark/benchmark.h> // for State, Benchmark, Counter, ClobberMemory, BENCHMARK
+
+#include <random>
+
+#include <hibf/sketch/hyperloglog.hpp>
+
+static void add(benchmark::State & state)
+{
+    uint8_t const bits = static_cast<uint8_t>(state.range(0));
+    seqan::hibf::sketch::hyperloglog hll{bits};
+    for (auto _ : state)
+    {
+        hll.add(23);
+    }
+    benchmark::DoNotOptimize(hll);
+}
+
+static void merge(benchmark::State & state)
+{
+    uint8_t const bits = static_cast<uint8_t>(state.range(0));
+    seqan::hibf::sketch::hyperloglog hll{bits};
+    for (auto _ : state)
+    {
+        hll.merge(hll);
+    }
+    benchmark::DoNotOptimize(hll);
+}
+
+static void estimate(benchmark::State & state)
+{
+    uint8_t const bits = static_cast<uint8_t>(state.range(0));
+    seqan::hibf::sketch::hyperloglog hll{bits};
+    double estimate{};
+    for (auto _ : state)
+    {
+        estimate = hll.estimate();
+    }
+    benchmark::DoNotOptimize(hll);
+    benchmark::DoNotOptimize(estimate);
+}
+
+static void merge_and_estimate(benchmark::State & state)
+{
+    uint8_t const bits = static_cast<uint8_t>(state.range(0));
+    seqan::hibf::sketch::hyperloglog hll{bits};
+    double estimate{};
+    for (auto _ : state)
+    {
+        estimate = hll.merge_and_estimate(hll);
+    }
+    benchmark::DoNotOptimize(hll);
+    benchmark::DoNotOptimize(estimate);
+}
+
+BENCHMARK(add)->DenseRange(5, 12, 1);
+BENCHMARK(merge)->DenseRange(5, 12, 1);
+BENCHMARK(estimate)->DenseRange(5, 12, 1);
+BENCHMARK(merge_and_estimate)->DenseRange(5, 12, 1);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Iterations are in thousands

| Benchmark          | Bits | Iterations before | Iterations after | Speedup |
|--------------------|------|-------------------|------------------|---------|
| add                | 5    | 303,112           | 302,424          | 1.0     |
| add                | 6    | 312,195           | 301,988          | 1.0     |
| add                | 7    | 307,077           | 304,696          | 1.0     |
| add                | 8    | 311,200           | 311,102          | 1.0     |
| add                | 9    | 311,268           | 310,932          | 1.0     |
| add                | 10   | 311,394           | 310,958          | 1.0     |
| add                | 11   | 311,388           | 311,060          | 1.0     |
| add                | 12   | 311,417           | 311,068          | 1.0     |
| merge              | 5    | 1,000,000         | 1,000,000        | 1.0     |
| merge              | 6    | 1,000,000         | 1,000,000        | 1.0     |
| merge              | 7    | 814,029           | 813,645          | 1.0     |
| merge              | 8    | 215,687           | 213,490          | 1.0     |
| merge              | 9    | 220,560           | 221,890          | 1.0     |
| merge              | 10   | 128,382           | 128,417          | 1.0     |
| merge              | 11   | 69,709            | 69,652           | 1.0     |
| merge              | 12   | 36,424            | 36,395           | 1.0     |
| estimate           | 5    | 20,056            | 37,375           | 1.9     |
| estimate           | 6    | 7,558             | 21,712           | 2.9     |
| estimate           | 7    | 3,703             | 12,470           | 3.4     |
| estimate           | 8    | 1,737             | 6,894            | 4.0     |
| estimate           | 9    | 869               | 3,576            | 4.1     |
| estimate           | 10   | 435               | 1,824            | 4.2     |
| estimate           | 11   | 217               | 916              | 4.2     |
| estimate           | 12   | 109               | 462              | 4.2     |
| merge_and_estimate | 5    | 19,685            | 36,999           | 1.9     |
| merge_and_estimate | 6    | 7,460             | 21,518           | 2.9     |
| merge_and_estimate | 7    | 3,665             | 12,617           | 3.4     |
| merge_and_estimate | 8    | 1,731             | 6,856            | 4.0     |
| merge_and_estimate | 9    | 865               | 3,565            | 4.1     |
| merge_and_estimate | 10   | 433               | 1,818            | 4.2     |
| merge_and_estimate | 11   | 217               | 913              | 4.2     |
| merge_and_estimate | 12   | 108               | 458              | 4.2     |