### PR TITLE
[FEATURE] Add layout::clear() function.

### DIFF
--- a/include/hibf/layout/layout.hpp
+++ b/include/hibf/layout/layout.hpp
@@ -78,6 +78,8 @@ struct layout
     void read_from(std::istream & stream);
     void write_to(std::ostream & stream) const;
 
+    void clear();
+
     size_t top_level_max_bin_id{};
     std::vector<max_bin> max_bins{};
     std::vector<user_bin> user_bins{};

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -142,4 +142,11 @@ void seqan::hibf::layout::layout::write_to(std::ostream & stream) const
         stream << user_bin << '\n';
 }
 
+void seqan::hibf::layout::layout::clear()
+{
+    top_level_max_bin_id = 0;
+    max_bins.clear();
+    user_bins.clear();
+}
+
 } // namespace seqan::hibf::layout

--- a/test/unit/hibf/layout/layout_test.cpp
+++ b/test/unit/hibf/layout/layout_test.cpp
@@ -54,6 +54,17 @@ TEST(layout_test, printing_user_bins)
     EXPECT_EQ(ss.str(), expected);
 }
 
+static std::string const layout_file{
+    R"layout_file(#TOP_LEVEL_IBF fullest_technical_bin_idx:111
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
+#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
+#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
+7	0	1
+4	1;0	1;22
+5	1;2;3;4;22	1;1;1;1;21
+)layout_file"};
+
 TEST(layout_test, write_to)
 {
     std::stringstream ss{};
@@ -70,30 +81,12 @@ TEST(layout_test, write_to)
 
     layout.write_to(ss);
 
-    std::string expected = R"layout_file(#TOP_LEVEL_IBF fullest_technical_bin_idx:111
-#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
-#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
-#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
-#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
-7	0	1
-4	1;0	1;22
-5	1;2;3;4;22	1;1;1;1;21
-)layout_file";
-
-    EXPECT_EQ(ss.str(), expected);
+    EXPECT_EQ(ss.str(), layout_file);
 }
 
 TEST(layout_test, read_from)
 {
-    std::stringstream ss{R"layout_file(#TOP_LEVEL_IBF fullest_technical_bin_idx:111
-#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
-#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
-#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
-#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
-7	0	1
-4	1;0	1;22
-5	1;2;3;4;22	1;1;1;1;21
-)layout_file"};
+    std::stringstream ss{layout_file};
 
     seqan::hibf::layout::layout layout;
     layout.read_from(ss);
@@ -105,4 +98,22 @@ TEST(layout_test, read_from)
     EXPECT_EQ(layout.user_bins[0], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{}, 0, 1, 7}));
     EXPECT_EQ(layout.user_bins[1], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1}, 0, 22, 4}));
     EXPECT_EQ(layout.user_bins[2], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1, 2, 3, 4}, 22, 21, 5}));
+}
+
+TEST(layout_test, clear)
+{
+    std::stringstream ss{layout_file};
+
+    seqan::hibf::layout::layout layout;
+    layout.read_from(ss);
+
+    ASSERT_NE(layout.top_level_max_bin_id, 0);
+    ASSERT_FALSE(layout.max_bins.empty());
+    ASSERT_FALSE(layout.user_bins.empty());
+
+    layout.clear();
+
+    EXPECT_EQ(layout.top_level_max_bin_id, 0);
+    EXPECT_TRUE(layout.max_bins.empty());
+    EXPECT_TRUE(layout.user_bins.empty());
 }


### PR DESCRIPTION
For the partitionied HIBF I need this when reading multiple layouts from a single file, clearing the layout in between.