### PR TITLE
[FEATURE] Multi-Layout file

### DIFF
--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -121,8 +121,10 @@ void seqan::hibf::layout::layout::read_from(std::istream & stream)
 
     assert(line == prefix::layout_column_names);
 
-    // parse the rest of the file
-    while (std::getline(stream, line))
+    // parse the rest of the file until either
+    // 1) the end of the file is reached
+    // 2) Another header line starts, which indicates a partitioned layout
+    while (stream.good() && static_cast<char>(stream.peek()) != prefix::layout_header[0] &&  std::getline(stream, line))
         user_bins.emplace_back(parse_layout_line(line));
 }
 

--- a/src/layout/layout.cpp
+++ b/src/layout/layout.cpp
@@ -124,7 +124,7 @@ void seqan::hibf::layout::layout::read_from(std::istream & stream)
     // parse the rest of the file until either
     // 1) the end of the file is reached
     // 2) Another header line starts, which indicates a partitioned layout
-    while (stream.good() && static_cast<char>(stream.peek()) != prefix::layout_header[0] &&  std::getline(stream, line))
+    while (stream.good() && static_cast<char>(stream.peek()) != prefix::layout_header[0] && std::getline(stream, line))
         user_bins.emplace_back(parse_layout_line(line));
 }
 

--- a/test/unit/hibf/layout/layout_test.cpp
+++ b/test/unit/hibf/layout/layout_test.cpp
@@ -130,7 +130,7 @@ TEST(layout_test, read_from_partitioned_layout)
 4	1;0	1;22
 5	1;2;3;4;22	1;1;1;1;21
 #TOP_LEVEL_IBF fullest_technical_bin_idx:111
-#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:1
 #LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
 #LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
 #USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
@@ -138,7 +138,7 @@ TEST(layout_test, read_from_partitioned_layout)
 4	1;0	1;22
 5	1;2;3;4;22	1;1;1;1;21
 #TOP_LEVEL_IBF fullest_technical_bin_idx:111
-#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:2
 #LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
 #LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
 #USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
@@ -153,7 +153,7 @@ TEST(layout_test, read_from_partitioned_layout)
         layout.read_from(ss);
 
         EXPECT_EQ(layout.top_level_max_bin_id, 111);
-        EXPECT_EQ(layout.max_bins[0], (seqan::hibf::layout::layout::max_bin{{0}, 0}));
+        EXPECT_EQ(layout.max_bins[0], (seqan::hibf::layout::layout::max_bin{{0}, i}));
         EXPECT_EQ(layout.max_bins[1], (seqan::hibf::layout::layout::max_bin{{2}, 2}));
         EXPECT_EQ(layout.max_bins[2], (seqan::hibf::layout::layout::max_bin{{1, 2, 3, 4}, 22}));
         EXPECT_EQ(layout.user_bins[0], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{}, 0, 1, 7}));

--- a/test/unit/hibf/layout/layout_test.cpp
+++ b/test/unit/hibf/layout/layout_test.cpp
@@ -158,6 +158,7 @@ TEST(layout_test, read_from_partitioned_layout)
         EXPECT_EQ(layout.max_bins[2], (seqan::hibf::layout::layout::max_bin{{1, 2, 3, 4}, 22}));
         EXPECT_EQ(layout.user_bins[0], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{}, 0, 1, 7}));
         EXPECT_EQ(layout.user_bins[1], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1}, 0, 22, 4}));
-        EXPECT_EQ(layout.user_bins[2], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1, 2, 3, 4}, 22, 21, 5}));
+        EXPECT_EQ(layout.user_bins[2],
+                  (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1, 2, 3, 4}, 22, 21, 5}));
     }
 }

--- a/test/unit/hibf/layout/layout_test.cpp
+++ b/test/unit/hibf/layout/layout_test.cpp
@@ -117,3 +117,47 @@ TEST(layout_test, clear)
     EXPECT_TRUE(layout.max_bins.empty());
     EXPECT_TRUE(layout.user_bins.empty());
 }
+
+TEST(layout_test, read_from_partitioned_layout)
+{
+    // layout consists of three partitions, written one after the other
+    std::stringstream ss{R"layout_file(#TOP_LEVEL_IBF fullest_technical_bin_idx:111
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
+#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
+#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
+7	0	1
+4	1;0	1;22
+5	1;2;3;4;22	1;1;1;1;21
+#TOP_LEVEL_IBF fullest_technical_bin_idx:111
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
+#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
+#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
+7	0	1
+4	1;0	1;22
+5	1;2;3;4;22	1;1;1;1;21
+#TOP_LEVEL_IBF fullest_technical_bin_idx:111
+#LOWER_LEVEL_IBF_0 fullest_technical_bin_idx:0
+#LOWER_LEVEL_IBF_2 fullest_technical_bin_idx:2
+#LOWER_LEVEL_IBF_1;2;3;4 fullest_technical_bin_idx:22
+#USER_BIN_IDX	TECHNICAL_BIN_INDICES	NUMBER_OF_TECHNICAL_BINS
+7	0	1
+4	1;0	1;22
+5	1;2;3;4;22	1;1;1;1;21
+)layout_file"};
+
+    for (size_t i = 0; i < 3; ++i)
+    {
+        seqan::hibf::layout::layout layout;
+        layout.read_from(ss);
+
+        EXPECT_EQ(layout.top_level_max_bin_id, 111);
+        EXPECT_EQ(layout.max_bins[0], (seqan::hibf::layout::layout::max_bin{{0}, 0}));
+        EXPECT_EQ(layout.max_bins[1], (seqan::hibf::layout::layout::max_bin{{2}, 2}));
+        EXPECT_EQ(layout.max_bins[2], (seqan::hibf::layout::layout::max_bin{{1, 2, 3, 4}, 22}));
+        EXPECT_EQ(layout.user_bins[0], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{}, 0, 1, 7}));
+        EXPECT_EQ(layout.user_bins[1], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1}, 0, 22, 4}));
+        EXPECT_EQ(layout.user_bins[2], (seqan::hibf::layout::layout::user_bin{std::vector<size_t>{1, 2, 3, 4}, 22, 21, 5}));
+    }
+}


### PR DESCRIPTION
This PR adds the possibility of a a single Layout file featuring multiple layouts. This is important in case of a partitioned HIBF.

When reading a layout, we formerly read until the end of the file.
Now we read either until the end of the file is reached OR a new header starts.

To read all layouts out of a layout file, one need to iteratively call `laout.read_from` on the stream.
