### PR TITLE
[MISC] Compute layout also takes positions.

### DIFF
--- a/include/hibf/layout/compute_layout.hpp
+++ b/include/hibf/layout/compute_layout.hpp
@@ -20,6 +20,7 @@ namespace seqan::hibf::layout
  * \param[in] config The configuration to compute the layout with.
  * \param[in] kmer_counts The vector that will store the kmer counts (estimations).
  * \param[in] sketches The vector that will store the sketches.
+ * \param[in] positions Specifies which user bins the layout should be calculated on (positions in the other vectors).
  * \param[in,out] union_estimation_timer The timer that measures the union estimation time.
  * \param[in,out] rearrangement_timer The timer that measures the rearrangement time.
  * \returns layout
@@ -27,6 +28,7 @@ namespace seqan::hibf::layout
 layout compute_layout(config const & config,
                       std::vector<size_t> const & kmer_counts,
                       std::vector<sketch::hyperloglog> const & sketches,
+                      std::vector<size_t> && positions,
                       concurrent_timer & union_estimation_timer,
                       concurrent_timer & rearrangement_timer);
 

--- a/include/hibf/misc/iota_vector.hpp
+++ b/include/hibf/misc/iota_vector.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+/*!\file
+ * \brief Provides seqan::hibf::iota_vector.
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ */
+
+#pragma once
+
+#include <cassert>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+#include <hibf/platform.hpp>
+
+namespace seqan::hibf
+{
+
+/*!\brief Creates a vector of size `size` with values from 0 to `size - 1`.
+ * \tparam value_t The value type of the vector. Defaults to `size_t`.
+ * \param[in] size The size of the vector.
+ * \returns A vector of size `size` with values from 0 to `size - 1`.
+*/
+template <std::unsigned_integral value_t = size_t>
+HIBF_CONSTEXPR_VECTOR std::vector<value_t> iota_vector(size_t const size)
+{
+    assert(size <= std::numeric_limits<value_t>::max());
+    std::vector<value_t> result(size);
+    std::iota(result.begin(), result.end(), value_t{});
+    return result;
+}
+
+} // namespace seqan::hibf

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -29,9 +29,10 @@
 #include <hibf/layout/graph.hpp>                          // for graph
 #include <hibf/layout/layout.hpp>                         // for layout
 #include <hibf/misc/divide_and_ceil.hpp>                  // for divide_and_ceil
-#include <hibf/misc/timer.hpp>                            // for concurrent_timer
-#include <hibf/sketch/compute_sketches.hpp>               // for compute_sketches
-#include <hibf/sketch/hyperloglog.hpp>                    // for hyperloglog
+#include <hibf/misc/iota_vector.hpp>
+#include <hibf/misc/timer.hpp>              // for concurrent_timer
+#include <hibf/sketch/compute_sketches.hpp> // for compute_sketches
+#include <hibf/sketch/hyperloglog.hpp>      // for hyperloglog
 
 namespace seqan::hibf
 {
@@ -223,6 +224,7 @@ hierarchical_interleaved_bloom_filter::hierarchical_interleaved_bloom_filter(con
     auto layout = layout::compute_layout(configuration,
                                          kmer_counts,
                                          sketches,
+                                         iota_vector(configuration.number_of_user_bins),
                                          layout_union_estimation_timer,
                                          layout_rearrangement_timer);
     layout_dp_algorithm_timer.stop();

--- a/test/unit/hibf/layout/compute_layout_test.cpp
+++ b/test/unit/hibf/layout/compute_layout_test.cpp
@@ -8,9 +8,10 @@
 #include <functional> // for function
 #include <vector>     // for vector, allocator
 
-#include <hibf/config.hpp>                  // for insert_iterator, config
-#include <hibf/layout/compute_layout.hpp>   // for compute_layout
-#include <hibf/layout/layout.hpp>           // for layout
+#include <hibf/config.hpp>                // for insert_iterator, config
+#include <hibf/layout/compute_layout.hpp> // for compute_layout
+#include <hibf/layout/layout.hpp>         // for layout
+#include <hibf/misc/iota_vector.hpp>
 #include <hibf/misc/timer.hpp>              // for concurrent_timer
 #include <hibf/sketch/compute_sketches.hpp> // for compute_sketches
 #include <hibf/sketch/hyperloglog.hpp>      // for hyperloglog
@@ -39,8 +40,12 @@ TEST(compute_layout, dispatch)
     seqan::hibf::concurrent_timer union_estimation_timer{};
     seqan::hibf::concurrent_timer rearrangement_timer{};
 
-    auto layout2 =
-        seqan::hibf::layout::compute_layout(config, kmer_counts, sketches, union_estimation_timer, rearrangement_timer);
+    auto layout2 = seqan::hibf::layout::compute_layout(config,
+                                                       kmer_counts,
+                                                       sketches,
+                                                       seqan::hibf::iota_vector(config.number_of_user_bins),
+                                                       union_estimation_timer,
+                                                       rearrangement_timer);
 
     EXPECT_TRUE(layout1 == layout2);
 }


### PR DESCRIPTION
Next step to make the hibf lib compatible with the incoming partitioned HIBF and Fast Layouted HIBF.

In that case, we do not always layout ALL user bins `[0,n-1]` but only part of them (e.g. only the first 10 for the first partition). Therefore, a layout needs to be able to be computed given an extra position vector, s.t. auxiliary information, e.g. sketches, remain untouched but I can pick whatever I need.

Fot the original layout, we just need to pass the original positions `[0,n-1]`.

Also not that the `data_store` of the layout already kept positions anyway to be able to sort user bins without modifying `sketches` and `kmer_counts`. I now simply made the positions accessible (set-able?) from the outside.