### PR TITLE
[FEATURE] Add MinHash sketches

### DIFF
--- a/include/hibf/sketch/compute_sketches.hpp
+++ b/include/hibf/sketch/compute_sketches.hpp
@@ -9,6 +9,7 @@
 
 #include <hibf/config.hpp>             // for config
 #include <hibf/sketch/hyperloglog.hpp> // for hyperloglog
+#include <hibf/sketch/minhashes.hpp>   // for minhash
 
 namespace seqan::hibf::sketch
 {
@@ -17,10 +18,21 @@ namespace seqan::hibf::sketch
  * \ingroup hibf_layout
  * \param[in] config The configuration to compute the layout with.
  * \param[in,out] kmer_counts The vector that will store the kmer counts (estimations).
- * \param[in,out] sketches The vector that will store the sketches.
+ * \param[in,out] hll_sketches The vector that will store the sketches.
  */
 void compute_sketches(config const & config,
                       std::vector<size_t> & kmer_counts,
-                      std::vector<sketch::hyperloglog> & sketches);
+                      std::vector<sketch::hyperloglog> & hll_sketches);
+
+//!\overload
+void compute_sketches(config const & config,
+                      std::vector<sketch::hyperloglog> & hll_sketches,
+                      std::vector<sketch::minhashes> & minhash_sketches);
+
+//!\overload
+void compute_sketches(config const & config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & hll_sketches,
+                      std::vector<sketch::minhashes> & minhash_sketches);
 
 } // namespace seqan::hibf::sketch

--- a/include/hibf/sketch/minhashes.hpp
+++ b/include/hibf/sketch/minhashes.hpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+/*!\file
+ * \author Svenja Mehringer <svenja.mehringer AT fu-berlin.de>
+ * \brief Provides seqan::hibf::sketch::minhashes.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include <hibf/platform.hpp>
+
+namespace seqan::hibf::sketch
+{
+
+/*!\brief MinHash sketches design to be used for Locality sensitive hashing
+ *
+ * The partitioned HIBF as well as the Fast Layout need minHash sketches for a locality sentive hashing
+ * algorithm that improves the user bin distribution.
+ *
+ * The sketches are specifically designed for this purpose:
+ *
+ * The `minhashes` struct keeps a table of several original MinHash sketches to be used for repeated
+ * iterations of LSH.
+ */
+struct minhashes
+{
+    static constexpr uint64_t register_id_mask{15}; /// ...00001111
+    static constexpr size_t num_sketches{16};
+    static constexpr size_t sketch_size{40};
+
+    //!\brief A table of sketches. For LSH we need multiple sketches, stored in a table.
+    std::vector<std::vector<uint64_t>> table{}; // Each element (vector<uint64_t>) is a minhash.
+
+    /*!\name Constructors, destructor and assignment
+     * \{
+     */
+    minhashes() = default;                              //!< Defaulted.
+    minhashes(minhashes const &) = default;             //!< Defaulted.
+    minhashes & operator=(minhashes const &) = default; //!< Defaulted.
+    minhashes(minhashes &&) = default;                  //!< Defaulted.
+    minhashes & operator=(minhashes &&) = default;      //!< Defaulted.
+    ~minhashes() = default;                             //!< Defaulted.
+    //!\brief construct from a vector of the smallest values in a set (sorted ascending).
+    minhashes(std::vector<uint64_t> const & smallest_values);
+    //!\}
+
+    //!\brief Checks whether the minHash table is completely filled.
+    bool is_valid() const;
+
+    //!\brief Adds more minhash values to an existing but incomplete table.
+    void fill_incomplete_sketches(std::span<uint64_t> const & more_smallest_values);
+
+    //!\brief Pushes `value` to the heap if it is smaller than the current largest element.
+    static void push_to_heap_if_smaller(uint64_t const value, std::vector<uint64_t> & heap);
+};
+
+} // namespace seqan::hibf::sketch

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set (HIBF_SOURCE_FILES
      misc/print.cpp
      sketch/toolbox.cpp
      sketch/hyperloglog.cpp
+     sketch/minhashes.cpp
      build/insert_into_ibf.cpp
      build/compute_kmers.cpp
      build/construct_ibf.cpp)

--- a/src/sketch/compute_sketches.cpp
+++ b/src/sketch/compute_sketches.cpp
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <atomic>
 #include <cinttypes>  // for uint64_t
 #include <cstddef>    // for size_t
 #include <functional> // for function
+#include <span>       // for vector
 #include <vector>     // for vector
 
 #include <hibf/config.hpp>                      // for config, insert_iterator
@@ -18,29 +20,151 @@ namespace seqan::hibf::sketch
 
 void compute_sketches(config const & config,
                       std::vector<size_t> & kmer_counts,
-                      std::vector<sketch::hyperloglog> & sketches)
+                      std::vector<sketch::hyperloglog> & hll_sketches)
 {
-    // compute sketches
-    sketches.resize(config.number_of_user_bins);
+    // compute hll_sketches
+    hll_sketches.resize(config.number_of_user_bins);
     kmer_counts.resize(config.number_of_user_bins);
 
     robin_hood::unordered_flat_set<uint64_t> kmers;
 #pragma omp parallel for schedule(dynamic) num_threads(config.threads) private(kmers)
     for (size_t i = 0; i < config.number_of_user_bins; ++i)
     {
-        seqan::hibf::sketch::hyperloglog sketch(config.sketch_bits);
+        seqan::hibf::sketch::hyperloglog hll_sketch(config.sketch_bits);
 
         kmers.clear();
         config.input_fn(i, insert_iterator{kmers});
 
         for (auto k_hash : kmers)
-            sketch.add(k_hash);
+            hll_sketch.add(k_hash);
 
-        // #pragma omp critical
-        sketches[i] = sketch;
+        hll_sketches[i] = std::move(hll_sketch);
     }
 
-    sketch::estimate_kmer_counts(sketches, kmer_counts);
+    sketch::estimate_kmer_counts(hll_sketches, kmer_counts);
+}
+
+/*!\brief Encapsulates handling of too few kmers to compute minHash sketches.
+ * \details
+ * OMP does not allow just throwing in a thread; it requires that the throw is handled in the same thread.
+ * In order to properly throw the exeception in the main thread, we need to set a flag.
+ * This flag then tells the other threads to stop working.
+ * Afterwards, the main thread can throw the exception.
+ */
+struct too_few_kmers_handler
+{
+    std::atomic_flag flag{};
+    size_t available{};
+
+    inline bool test() noexcept
+    {
+        return flag.test();
+    }
+
+    inline void set(size_t const available) noexcept
+    {
+        // Sets the flag to true and returns previous value.
+        // If the flag was already set, another thread encountered this block at the same time.
+        // This basically acts as a mutex for setting available.
+        if (!flag.test_and_set())
+            this->available = available;
+    }
+
+    inline void check_and_throw()
+    {
+        if (test())
+            throw std::runtime_error{"Not enough kmers (" + std::to_string(available) + ") to get "
+                                     + std::to_string(minhashes::num_sketches * minhashes::sketch_size)
+                                     + " hashes for all minHash sketches."};
+    }
+};
+
+// minhash_sketches data structure:
+// Vector L1 : number of user bins
+// Vector L2 : number_of_max_minhash_sketches (LSH ADD+OR parameter b)
+// Vector L3 : minHash_sketche_size (LSH ADD+OR parameter r)
+void compute_sketches(config const & config,
+                      std::vector<sketch::hyperloglog> & hll_sketches,
+                      std::vector<sketch::minhashes> & minhash_sketches)
+{
+    //inititalise
+    hll_sketches.resize(config.number_of_user_bins);
+    minhash_sketches.resize(config.number_of_user_bins);
+
+    // compute hll_sketches
+    robin_hood::unordered_flat_set<uint64_t> kmers{};
+
+    too_few_kmers_handler too_few_kmers{};
+
+    std::vector<uint64_t> heap{};
+
+#pragma omp parallel for schedule(dynamic) num_threads(config.threads) private(kmers) private(heap)
+    for (size_t i = 0; i < config.number_of_user_bins; ++i)
+    {
+        // Skip work if we already know that we have too few kmers.
+        if (too_few_kmers.test())
+            continue;
+
+        seqan::hibf::sketch::hyperloglog hll_sketch{config.sketch_bits};
+
+        kmers.clear();
+        config.input_fn(i, insert_iterator{kmers});
+
+        size_t heap_size{1000};
+        heap.resize(heap_size);
+        std::ranges::fill(heap, std::numeric_limits<uint64_t>::max()); // proper heap
+
+        for (auto const hash : kmers)
+        {
+            hll_sketch.add(hash);
+            seqan::hibf::sketch::minhashes::push_to_heap_if_smaller(hash, heap);
+        }
+
+        std::ranges::sort_heap(heap); // sort ascending to get the smallest numbers first
+
+        seqan::hibf::sketch::minhashes minhash_sketch{heap};
+
+        // In case the former heap_size wasn't sufficient to fill the minhash table
+        // we need to increase the heap size and fill the heap further. We can take advantage of values
+        // that already had been in the heap because they are still the smallest ones.
+        while (!minhash_sketch.is_valid() && !too_few_kmers.test())
+        {
+            heap_size *= 2;
+
+            if (heap_size > kmers.size())
+            {
+                too_few_kmers.set(kmers.size());
+                break;
+            }
+
+            heap.resize(heap_size, std::numeric_limits<uint64_t>::max());
+            std::ranges::make_heap(heap);
+
+            for (auto const hash : kmers)
+                seqan::hibf::sketch::minhashes::push_to_heap_if_smaller(hash, heap);
+
+            std::ranges::sort_heap(heap); // sort ascending to get the smallest numbers first
+
+            assert(heap_size % 2u == 0u);
+            std::span<uint64_t> const heap_to_consider(heap.begin() + heap_size / 2, heap.end());
+            minhash_sketch.fill_incomplete_sketches(heap_to_consider);
+        }
+
+        hll_sketches[i] = std::move(hll_sketch);
+        minhash_sketches[i] = std::move(minhash_sketch);
+    }
+
+    too_few_kmers.check_and_throw();
+}
+
+void compute_sketches(config const & config,
+                      std::vector<size_t> & kmer_counts,
+                      std::vector<sketch::hyperloglog> & hll_sketches,
+                      std::vector<sketch::minhashes> & minhash_sketches)
+{
+    compute_sketches(config, hll_sketches, minhash_sketches);
+    kmer_counts.resize(config.number_of_user_bins);
+    sketch::estimate_kmer_counts(hll_sketches, kmer_counts);
 }
 
 } // namespace seqan::hibf::sketch

--- a/src/sketch/minhashes.cpp
+++ b/src/sketch/minhashes.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <algorithm>
+#include <cassert>
+
+#include <hibf/sketch/minhashes.hpp>
+
+namespace seqan::hibf::sketch
+{
+
+minhashes::minhashes(std::vector<uint64_t> const & smallest_values)
+{
+    assert(std::ranges::is_sorted(smallest_values));
+
+    table.resize(num_sketches);
+
+    for (auto & elem : table)
+        elem.reserve(sketch_size);
+
+    for (uint64_t const hash : smallest_values)
+    {
+        auto & hash_table = table[hash & register_id_mask];
+        if (hash_table.size() < sketch_size)
+            hash_table.push_back(hash >> 4);
+    }
+}
+
+bool minhashes::is_valid() const
+{
+    return table.size() == num_sketches
+        && std::ranges::all_of(table,
+                               [](auto const & minHash_sketch)
+                               {
+                                   return minHash_sketch.size() == sketch_size;
+                               });
+}
+
+void minhashes::fill_incomplete_sketches(std::span<uint64_t> const & more_smallest_values)
+{
+    assert(std::ranges::is_sorted(more_smallest_values));
+
+    for (uint64_t const hash : more_smallest_values)
+    {
+        auto & hash_table = table[hash & register_id_mask];
+        assert(std::ranges::find(hash_table, hash) == hash_table.end()); // hashes should be unique
+        if (hash_table.size() < sketch_size)
+            hash_table.push_back(hash >> 4);
+    }
+}
+
+void minhashes::push_to_heap_if_smaller(uint64_t const value, std::vector<uint64_t> & heap)
+{
+    // Do nothing if value is bigger than the current biggest element in the (max) heap.
+    if (value >= heap[0])
+        return;
+
+    // we do not need a guard (hash table) to check for duplications because `kmers` is already a set
+    std::ranges::pop_heap(heap);  // max elements move to end of vector
+    heap.back() = value;          // replace last elements instead of physically popping and pushing
+    std::ranges::push_heap(heap); // last elements is rearranged in the heap to be pushed
+}
+
+} // namespace seqan::hibf::sketch

--- a/test/include/hibf/test/expect_range_eq.hpp
+++ b/test/include/hibf/test/expect_range_eq.hpp
@@ -42,7 +42,7 @@ void PrintTo(t const & value, std::ostream * out)
 namespace seqan::hibf::test
 {
 
-#define EXPECT_RANGE_EQ(val1, val2) EXPECT_PRED_FORMAT2(::seqan::hibf::test::expect_range_eq{}, val1, val2);
+#define EXPECT_RANGE_EQ(val1, val2) EXPECT_PRED_FORMAT2(::seqan::hibf::test::expect_range_eq{}, val1, val2)
 
 struct expect_range_eq
 {

--- a/test/performance/sketch/CMakeLists.txt
+++ b/test/performance/sketch/CMakeLists.txt
@@ -2,4 +2,5 @@
 # SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
 # SPDX-License-Identifier: BSD-3-Clause
 
+hibf_benchmark (compute_sketches_benchmark.cpp)
 hibf_benchmark (hyperloglog_benchmark.cpp)

--- a/test/performance/sketch/compute_sketches_benchmark.cpp
+++ b/test/performance/sketch/compute_sketches_benchmark.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <benchmark/benchmark.h>
+
+#include <hibf/sketch/compute_sketches.hpp>
+
+enum class sketch : uint8_t
+{
+    Hyperloglog,
+    MinHashes
+};
+
+template <sketch sketch_t>
+void compute_sketches(benchmark::State & state)
+{
+    auto create_hashes = [&](size_t const ub_id, seqan::hibf::insert_iterator it)
+    {
+        // 0 = [0, 10000]
+        // 1 = [10000, 20000]
+        // 1 = [20000, 30000]
+        for (size_t i = ub_id * 10000; i < (ub_id + 1) * 10000; ++i)
+            it = i;
+    };
+
+    std::vector<size_t> kmer_counts;
+    [[maybe_unused]] std::vector<seqan::hibf::sketch::minhashes> minhash_sketches;
+    std::vector<seqan::hibf::sketch::hyperloglog> hyperloglog_sketches;
+
+    seqan::hibf::config config{};
+    config.number_of_user_bins = 16;
+    config.input_fn = create_hashes;
+    config.sketch_bits = 12;
+
+    for (auto _ : state)
+    {
+        if constexpr (sketch_t == sketch::MinHashes)
+            seqan::hibf::sketch::compute_sketches(config, kmer_counts, hyperloglog_sketches, minhash_sketches);
+        else
+            seqan::hibf::sketch::compute_sketches(config, kmer_counts, hyperloglog_sketches);
+    }
+}
+
+BENCHMARK_TEMPLATE(compute_sketches, sketch::Hyperloglog);
+BENCHMARK_TEMPLATE(compute_sketches, sketch::MinHashes);

--- a/test/unit/hibf/sketch/CMakeLists.txt
+++ b/test/unit/hibf/sketch/CMakeLists.txt
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
 # SPDX-License-Identifier: BSD-3-Clause
 
+hibf_test (compute_sketches_test.cpp)
 hibf_test (estimate_kmer_counts_test.cpp)
 hibf_test (hyperloglog_test.cpp)
 hibf_test (toolbox_test.cpp)
+hibf_test (minhashes_test.cpp)

--- a/test/unit/hibf/sketch/compute_sketches_test.cpp
+++ b/test/unit/hibf/sketch/compute_sketches_test.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest-spi.h>
+#include <gtest/gtest.h> // for Test, Message, TestPartResult, EXPECT_EQ, TestInfo, ASSERT_EQ
+
+#include <cinttypes> // for uint64_t
+#include <cstddef>   // for size_t
+#include <random>    // for uniform_int_distribution, mt19937_64
+#include <vector>    // for allocator, vector
+
+#include <hibf/sketch/compute_sketches.hpp>
+#include <hibf/test/expect_range_eq.hpp> // for expect_range_eq, EXPECT_RANGE_EQ
+
+class compute_sketches_test : public ::testing::Test
+{
+public:
+    std::vector<size_t> kmer_counts;
+    std::vector<seqan::hibf::sketch::hyperloglog> hyperloglog_sketches;
+    std::vector<seqan::hibf::sketch::minhashes> minhash_sketches;
+    seqan::hibf::config config;
+
+    void SetUp() override
+    {
+        config.number_of_user_bins = 3;
+        config.sketch_bits = 12;
+        config.input_fn = [&](size_t const ub_id, seqan::hibf::insert_iterator it)
+        {
+            // 0 = [0, 10000]
+            // 1 = [10000, 20000]
+            // 1 = [20000, 30000]
+            for (size_t i = ub_id * 10000; i < (ub_id + 1) * 10000; ++i)
+                it = i;
+        };
+    }
+
+    void check_kmer_counts()
+    {
+        ASSERT_EQ(kmer_counts.size(), 3);
+        EXPECT_EQ(kmer_counts[0], 18405);
+        EXPECT_EQ(kmer_counts[1], 18429);
+        EXPECT_EQ(kmer_counts[2], 18427);
+    }
+
+    void check_hyperloglog_sketches()
+    {
+        ASSERT_EQ(hyperloglog_sketches.size(), 3);
+        constexpr double abs_error = 0.00001;
+        EXPECT_NEAR(hyperloglog_sketches[0].estimate(), 18405.11680625227, abs_error);
+        EXPECT_NEAR(hyperloglog_sketches[1].estimate(), 18429.448850770688, abs_error);
+        EXPECT_NEAR(hyperloglog_sketches[2].estimate(), 18427.74236590719, abs_error);
+    }
+
+    void check_minhash_sketches()
+    {
+        ASSERT_EQ(minhash_sketches.size(), 3);
+        size_t start{};
+        size_t ub_id{};
+        for (auto & minhash : minhash_sketches)
+        {
+            ASSERT_TRUE(minhash.is_valid()) << "ub_id: " << ub_id;
+            size_t sid{};
+            for (auto & sketch : minhash.table)
+            {
+                ASSERT_EQ(sketch.size(), seqan::hibf::sketch::minhashes::sketch_size)
+                    << "ub_id: " << ub_id << "sid: " << sid;
+                EXPECT_RANGE_EQ(sketch, std::views::iota(start, start + seqan::hibf::sketch::minhashes::sketch_size))
+                    << "ub_id: " << ub_id << "sid: " << sid;
+                ++sid;
+            }
+            start += 625;
+            ++ub_id;
+        }
+    }
+};
+
+TEST_F(compute_sketches_test, hyperloglog_and_kmer_counts)
+{
+    seqan::hibf::sketch::compute_sketches(this->config, this->kmer_counts, this->hyperloglog_sketches);
+
+    this->check_kmer_counts();
+    this->check_hyperloglog_sketches();
+}
+
+TEST_F(compute_sketches_test, with_minHash)
+{
+    seqan::hibf::sketch::compute_sketches(this->config, this->hyperloglog_sketches, this->minhash_sketches);
+
+    this->check_hyperloglog_sketches();
+    this->check_minhash_sketches();
+}
+
+TEST_F(compute_sketches_test, with_minHash_and_kmer_counts)
+{
+    seqan::hibf::sketch::compute_sketches(this->config,
+                                          this->kmer_counts,
+                                          this->hyperloglog_sketches,
+                                          this->minhash_sketches);
+
+    this->check_hyperloglog_sketches();
+    this->check_minhash_sketches();
+}
+
+TEST_F(compute_sketches_test, too_few_hashes)
+{
+    this->config.number_of_user_bins = 1;
+    this->config.sketch_bits = 12;
+    this->config.input_fn = [&](size_t const, seqan::hibf::insert_iterator it)
+    {
+        for (size_t i = 0; i < 100; ++i)
+            it = i;
+    };
+
+    EXPECT_THROW(
+        seqan::hibf::sketch::compute_sketches(this->config, this->hyperloglog_sketches, this->minhash_sketches),
+        std::runtime_error);
+}

--- a/test/unit/hibf/sketch/minhashes_test.cpp
+++ b/test/unit/hibf/sketch/minhashes_test.cpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2006-2024, Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024, Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <gtest/gtest.h> // for Test, Message, TestInfo, TestPartResult, TEST, EXPECT_EQ
+
+#include <hibf/misc/iota_vector.hpp>     // for iota_vector
+#include <hibf/sketch/minhashes.hpp>     // for minhash
+#include <hibf/test/expect_range_eq.hpp> // for expect_range_eq, EXPECT_RANGE_EQ
+
+TEST(minhashes_test, ctor)
+{
+    seqan::hibf::sketch::minhashes default_ctor{};
+    EXPECT_TRUE(default_ctor.table.empty());
+    EXPECT_FALSE(default_ctor.is_valid());
+
+    seqan::hibf::sketch::minhashes copy_ctor{default_ctor};
+    EXPECT_TRUE(copy_ctor.table.empty());
+    EXPECT_FALSE(copy_ctor.is_valid());
+
+    seqan::hibf::sketch::minhashes copy_assignment{};
+    copy_assignment = default_ctor;
+    EXPECT_TRUE(copy_assignment.table.empty());
+    EXPECT_FALSE(copy_assignment.is_valid());
+
+    seqan::hibf::sketch::minhashes move_ctor{std::move(default_ctor)};
+    EXPECT_TRUE(move_ctor.table.empty());
+    EXPECT_FALSE(move_ctor.is_valid());
+
+    seqan::hibf::sketch::minhashes move_assignment{};
+    move_assignment = std::move(copy_ctor);
+    EXPECT_TRUE(move_assignment.table.empty());
+    EXPECT_FALSE(move_assignment.is_valid());
+}
+
+TEST(minhashes_test, push_to_heap_if_smaller)
+{
+    std::vector<uint64_t> heap{3, 4, 5, 6, 7, 8};
+    std::ranges::make_heap(heap);
+
+    // No change because 10 is larger than all values in the heap
+    std::vector<uint64_t> const original_heap{heap};
+    seqan::hibf::sketch::minhashes::push_to_heap_if_smaller(10, heap);
+    EXPECT_RANGE_EQ(original_heap, heap);
+
+    // Heap changes
+    seqan::hibf::sketch::minhashes::push_to_heap_if_smaller(0, heap);
+    EXPECT_FALSE(std::ranges::equal(original_heap, heap));
+    EXPECT_EQ(heap[0], 7u); // largest element is now 7 (not 8 anymore)
+}
+
+TEST(minhashes_test, ctor_sorted_list)
+{
+    std::vector<uint64_t> const heap = seqan::hibf::iota_vector<uint64_t>(1000);
+
+    seqan::hibf::sketch::minhashes sketches{heap};
+
+    // check for correct construction
+    EXPECT_FALSE(sketches.table.empty());
+    EXPECT_TRUE(sketches.is_valid());
+
+    ASSERT_EQ(sketches.table.size(), seqan::hibf::sketch::minhashes::num_sketches);
+
+    size_t sid{};
+    for (auto & sketch : sketches.table)
+    {
+        ASSERT_EQ(sketch.size(), seqan::hibf::sketch::minhashes::sketch_size) << "sid: " << sid;
+        EXPECT_RANGE_EQ(sketch, std::views::iota(0u, seqan::hibf::sketch::minhashes::sketch_size)) << "sid: " << sid;
+        ++sid;
+    }
+}
+
+TEST(minhashes_test, fill_incomplete_sketches)
+{
+    std::vector<uint64_t> const heap = seqan::hibf::iota_vector<uint64_t>(10);
+
+    seqan::hibf::sketch::minhashes sketches{heap}; // there will be too few values
+    EXPECT_FALSE(sketches.table.empty());
+    ASSERT_FALSE(sketches.is_valid());
+
+    // recreate bigger heap
+    std::vector<uint64_t> bigger_heap = seqan::hibf::iota_vector<uint64_t>(1000);
+    std::span<uint64_t> const bigger_heap_non_redundant(bigger_heap.begin() + heap.size(), bigger_heap.end());
+    sketches.fill_incomplete_sketches(bigger_heap_non_redundant);
+
+    // check if filling up worked correctly
+    ASSERT_TRUE(sketches.is_valid());
+
+    ASSERT_EQ(sketches.table.size(), seqan::hibf::sketch::minhashes::num_sketches);
+
+    size_t sid{};
+    for (auto & sketch : sketches.table)
+    {
+        ASSERT_EQ(sketch.size(), seqan::hibf::sketch::minhashes::sketch_size) << "sid: " << sid;
+        EXPECT_RANGE_EQ(sketch, std::views::iota(0u, seqan::hibf::sketch::minhashes::sketch_size)) << "sid: " << sid;
+        ++sid;
+    }
+}


### PR DESCRIPTION
Fast Layout and the partitioned HIBF need minHash sketches for locality sensitive hashing.

Currently both live solely in chopper but I think they should be within the hibf lib so the sketches will move here first.
