### PR TITLE
[FEATURE] Make hll and minhash sketches cerealisable 

### DIFF
--- a/include/hibf/sketch/hyperloglog.hpp
+++ b/include/hibf/sketch/hyperloglog.hpp
@@ -18,6 +18,7 @@
 #include <vector>    // for vector
 
 #include <cereal/cereal.hpp>
+#include <cereal/types/vector.hpp>
 
 #include <hibf/contrib/aligned_allocator.hpp> // for aligned_allocator
 #include <hibf/platform.hpp>

--- a/include/hibf/sketch/hyperloglog.hpp
+++ b/include/hibf/sketch/hyperloglog.hpp
@@ -17,6 +17,8 @@
 #include <iosfwd>    // for istream, ostream
 #include <vector>    // for vector
 
+#include <cereal/cereal.hpp>
+
 #include <hibf/contrib/aligned_allocator.hpp> // for aligned_allocator
 #include <hibf/platform.hpp>
 
@@ -125,6 +127,21 @@ private:
     double normalization_factor{};
     //!\brief Internal data. Also called register in publications.
     std::vector<uint8_t, seqan::hibf::contrib::aligned_allocator<uint8_t, 32u>> data{};
+
+    friend class cereal::access;
+
+    template <typename archive_t>
+    void serialize(archive_t & archive)
+    {
+        uint32_t version{2};
+        archive(CEREAL_NVP(version));
+
+        archive(CEREAL_NVP(bits));
+        archive(CEREAL_NVP(size));
+        archive(CEREAL_NVP(rank_mask));
+        archive(CEREAL_NVP(normalization_factor));
+        archive(CEREAL_NVP(data));
+    }
 };
 
 } // namespace seqan::hibf::sketch

--- a/include/hibf/sketch/hyperloglog.hpp
+++ b/include/hibf/sketch/hyperloglog.hpp
@@ -134,7 +134,7 @@ private:
     template <typename archive_t>
     void serialize(archive_t & archive)
     {
-        uint32_t version{2};
+        uint32_t version{1};
         archive(CEREAL_NVP(version));
 
         archive(CEREAL_NVP(bits));

--- a/include/hibf/sketch/minhashes.hpp
+++ b/include/hibf/sketch/minhashes.hpp
@@ -14,6 +14,8 @@
 #include <span>    // for span
 #include <vector>  // for vector
 
+#include <cereal/cereal.hpp>
+
 #include <hibf/platform.hpp>
 
 namespace seqan::hibf::sketch
@@ -59,6 +61,19 @@ struct minhashes
 
     //!\brief Pushes `value` to the heap if it is smaller than the current largest element.
     static void push_to_heap_if_smaller(uint64_t const value, std::vector<uint64_t> & heap);
+
+private:
+    friend class cereal::access;
+
+    template <typename archive_t>
+    void serialize(archive_t & archive)
+    {
+        uint32_t version{1};
+        archive(CEREAL_NVP(version));
+
+        // other members are const static currently
+        archive(CEREAL_NVP(table));
+    }
 };
 
 } // namespace seqan::hibf::sketch


### PR DESCRIPTION
Reading and writing now works in chopper with this branch on a test data set. I did not test it on the big data, as a benchmark is running and all the data is on augustus.
I will check it before doing the PR for chopper, but this minor PR for the HIBF lib could already be reviewed/merged.