### PR TITLE
[MISC] Use uint64_t::max() for merged bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ int main()
     auto & result1 = agent.membership_for(query1, 2u);
 
     // query1 hits in user_bin_1 and user_bin_3, which have the IDs 0 and 2, respectively.
-    for (int64_t hit_user_bin : result1)
+    for (uint64_t hit_user_bin : result1)
         std::cout << hit_user_bin << ' '; // The results are not sorted: 2 0
     std::cout << '\n';
 
@@ -154,7 +154,7 @@ int main()
     agent.sort_results(); // Sort the results.
 
     // query2 hits in user_bin_1 and user_bin_2, which have the IDs 0 and 1, respectively.
-    for (int64_t hit_user_bin : result2)
+    for (uint64_t hit_user_bin : result2)
         std::cout << hit_user_bin << ' '; // The results are sorted: 0 1
     std::cout << '\n';
 }

--- a/include/hibf/build/update_user_bins.hpp
+++ b/include/hibf/build/update_user_bins.hpp
@@ -16,7 +16,7 @@ namespace seqan::hibf::build
 /*!\brief Updates user bins stored in HIBF.
  * \ingroup hibf_build
  */
-inline void update_user_bins(std::vector<int64_t> & filename_indices, layout::layout::user_bin const & record)
+inline void update_user_bins(std::vector<uint64_t> & filename_indices, layout::layout::user_bin const & record)
 {
     std::fill_n(filename_indices.begin() + record.storage_TB_id, record.number_of_technical_bins, record.idx);
 }

--- a/include/hibf/config.hpp
+++ b/include/hibf/config.hpp
@@ -113,6 +113,8 @@ struct config
      * Since the data to construct the (H)IBF is given by a function object `seqan::hibf::config::input_fn`,
      * the number of user bins to consider must be given via this option.
      *
+     * Value must be neither `0` nor `std::numeric_limits<uint64_t>::max()`.
+     *
      * \include test/snippet/hibf/config_number_of_user_bins.cpp
      *
      * In this example, `12` user bins would be inserted into the (H)IBF, each only storing the hash `42`.
@@ -288,7 +290,7 @@ struct config
     /*!\brief Checks several variables of seqan::hibf::config and sets default values if necessary.
      *
      * Required options:
-     *   * seqan::hibf::config::number_of_user_bins must be set to a value other than `0`.
+     *   * seqan::hibf::config::number_of_user_bins must be neither `0` nor `std::numeric_limits<uint64_t>::max()`.
      *   * seqan::hibf::config::input_fn must be set.
      *
      * Constrains:

--- a/include/hibf/misc/print.hpp
+++ b/include/hibf/misc/print.hpp
@@ -30,7 +30,7 @@ struct print_t
     void operator()(seqan::hibf::counting_vector<int16_t> const & vector, std::ostream & stream = std::cout) const;
     void operator()(seqan::hibf::counting_vector<int32_t> const & vector, std::ostream & stream = std::cout) const;
     void operator()(seqan::hibf::counting_vector<int64_t> const & vector, std::ostream & stream = std::cout) const;
-    void operator()(std::vector<int64_t> const & vector, std::ostream & stream = std::cout) const;
+    void operator()(std::vector<uint64_t> const & vector, std::ostream & stream = std::cout) const;
 };
 
 static inline constexpr auto print = print_t{};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -69,6 +69,10 @@ void config::validate_and_set_defaults()
     if (number_of_user_bins == 0u)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] You did not set the required config::number_of_user_bins."};
 
+    if (number_of_user_bins == 18'446'744'073'709'551'615ULL) // std::numeric_limits<uint64_t>::max() = bin_kind::merged
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] The maximum possible config::number_of_user_bins "
+                                    "is 18446744073709551614."};
+
     if (number_of_hash_functions == 0u || number_of_hash_functions > 5u)
         throw std::invalid_argument{"[HIBF CONFIG ERROR] config::number_of_hash_functions must be in [1,5]."};
 
@@ -97,7 +101,7 @@ void config::validate_and_set_defaults()
     }
     else if (tmax > 18'446'744'073'709'551'552ULL) // next_multiple_of_64 would not fit in size_t. Underflowed by user?
     {
-        throw std::invalid_argument{"[HIBF CONFIG ERROR] The maximum possible tmax is 18446744073709551552."};
+        throw std::invalid_argument{"[HIBF CONFIG ERROR] The maximum possible config::tmax is 18446744073709551552."};
     }
     else if (tmax % 64 != 0)
     {

--- a/src/hierarchical_interleaved_bloom_filter.cpp
+++ b/src/hierarchical_interleaved_bloom_filter.cpp
@@ -46,8 +46,8 @@ size_t hierarchical_build(hierarchical_interleaved_bloom_filter & hibf,
 {
     size_t const ibf_pos{data.request_ibf_idx()};
 
-    std::vector<int64_t> ibf_positions(current_node.number_of_technical_bins, ibf_pos);
-    std::vector<int64_t> filename_indices(current_node.number_of_technical_bins, -1);
+    std::vector<uint64_t> ibf_positions(current_node.number_of_technical_bins, ibf_pos);
+    std::vector<uint64_t> filename_indices(current_node.number_of_technical_bins, bin_kind::merged);
     robin_hood::unordered_flat_set<uint64_t> kmers{};
 
     auto initialise_max_bin_kmers = [&]() -> size_t

--- a/src/misc/print.cpp
+++ b/src/misc/print.cpp
@@ -102,7 +102,7 @@ void print_t::operator()(seqan::hibf::counting_vector<int64_t> const & vector, s
     print_impl(vector, stream);
 }
 
-void print_t::operator()(std::vector<int64_t> const & vector, std::ostream & stream) const
+void print_t::operator()(std::vector<uint64_t> const & vector, std::ostream & stream) const
 {
     print_impl(vector, stream);
 }

--- a/test/snippet/readme.cpp
+++ b/test/snippet/readme.cpp
@@ -77,7 +77,7 @@ int main()
     auto & result1 = agent.membership_for(query1, 2u);
 
     // query1 hits in user_bin_1 and user_bin_3, which have the IDs 0 and 2, respectively.
-    for (int64_t hit_user_bin : result1)
+    for (uint64_t hit_user_bin : result1)
         std::cout << hit_user_bin << ' '; // The results are not sorted: 2 0
     std::cout << '\n';
 
@@ -88,7 +88,7 @@ int main()
     agent.sort_results(); // Sort the results.
 
     // query2 hits in user_bin_1 and user_bin_2, which have the IDs 0 and 1, respectively.
-    for (int64_t hit_user_bin : result2)
+    for (uint64_t hit_user_bin : result2)
         std::cout << hit_user_bin << ' '; // The results are sorted: 0 1
     std::cout << '\n';
 }

--- a/test/unit/hibf/config_test.cpp
+++ b/test/unit/hibf/config_test.cpp
@@ -162,11 +162,16 @@ TEST(config_test, validate_and_set_defaults)
         check_error_message(configuration, "[HIBF CONFIG ERROR] You did not set the required config::input_fn.");
     }
 
-    // number_of_user_bins cannot be 0
+    // number_of_user_bins cannot be 0 or bin_kind::merged (18'446'744'073'709'551'615ULL)
     {
         seqan::hibf::config configuration{.input_fn = dummy_input_fn};
         check_error_message(configuration,
                             "[HIBF CONFIG ERROR] You did not set the required config::number_of_user_bins.");
+
+        configuration.number_of_user_bins = 18'446'744'073'709'551'615ULL;
+        check_error_message(configuration,
+                            "[HIBF CONFIG ERROR] The maximum possible config::number_of_user_bins "
+                            "is 18446744073709551614.");
     }
 
     // number_of_hash_functions must be in [1,5]
@@ -255,7 +260,9 @@ TEST(config_test, validate_and_set_defaults)
                                           .number_of_user_bins = 1u,
                                           .tmax = 18'446'744'073'709'551'553ULL};
 
-        check_error_message(configuration, "[HIBF CONFIG ERROR] The maximum possible tmax is 18446744073709551552.");
+        check_error_message(configuration,
+                            "[HIBF CONFIG ERROR] The maximum possible config::tmax "
+                            "is 18446744073709551552.");
     }
 
     // Given tmax is not a multiple of 64

--- a/test/unit/hibf/print_test.cpp
+++ b/test/unit/hibf/print_test.cpp
@@ -26,7 +26,7 @@ using test_types = ::testing::Types<seqan::hibf::bit_vector,
                                     seqan::hibf::counting_vector<int16_t>,
                                     seqan::hibf::counting_vector<int32_t>,
                                     seqan::hibf::counting_vector<int64_t>,
-                                    std::vector<int64_t>>;
+                                    std::vector<uint64_t>>;
 
 TYPED_TEST_SUITE(print_test, test_types);
 


### PR DESCRIPTION
Luckily, `-1` and `std::numeric_limits<uint64_t>::max()` have the same binary representation, so no breakage for serialisation.
https://godbolt.org/z/756arGfMK

This also solves the problem that `number_of_user_bins` is unsigned, but the internal representation for the user bin IDs uses signed integers. The previous maximum `number_of_user_bins` was actually `std::numeric_limits<int64_t>::max()`.