### PR TITLE
[INFRA] Better LTO handling

### DIFF
--- a/cmake/hibf-config.cmake.in
+++ b/cmake/hibf-config.cmake.in
@@ -4,6 +4,8 @@
 
 @PACKAGE_INIT@
 
+include (CheckIPOSupported)
+include (CMakeDependentOption)
 include (CMakeFindDependencyMacro)
 
 find_dependency (cereal @HIBF_CEREAL_VERSION@ REQUIRED)
@@ -24,6 +26,24 @@ if (simde_FOUND)
     target_include_directories (simde INTERFACE ${simde_INCLUDEDIR})
 else ()
     find_dependency (simde @HIBF_SIMDE_VERSION@ REQUIRED)
+endif ()
+
+check_ipo_supported (RESULT HIBF_HAS_LTO OUTPUT HIBF_HAS_LTO_OUTPUT)
+cmake_dependent_option (HIBF_DEV_CHECK_LTO "LTO check." ON "HIBF_HAS_LTO;NOT CMAKE_INTERPROCEDURAL_OPTIMIZATION" OFF)
+
+if (HIBF_DEV_CHECK_LTO)
+    message (FATAL_ERROR " HIBF heavily benefits from Link Time Optimisation (LTO).\n"
+                         " Your compiler supports LTO, but is has not been enabled for your project.\n \n"
+                         " Add the following at the beginning of your CMakeLists.txt:\n"
+                         " ```\n"
+                         " include (CheckIPOSupported)\n"
+                         " check_ipo_supported (RESULT result OUTPUT output)\n"
+                         " if (result)\n"
+                         "     set (CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)\n"
+                         " endif ()\n"
+                         " ```"
+                         " \n \n"
+                         " For development purposes, this error can be disabled via `HIBF_DEV_CHECK_LTO=OFF`.")
 endif ()
 
 include ("${CMAKE_CURRENT_LIST_DIR}/hibf-targets.cmake")

--- a/cmake/package-lock.cmake
+++ b/cmake/package-lock.cmake
@@ -19,7 +19,7 @@ CPMDeclarePackage (simde
                    NAME simde
                    VERSION ${HIBF_SIMDE_VERSION}
                    GITHUB_REPOSITORY simd-everywhere/simde
-                   DOWNLOAD_ONLY YES)
+                   DOWNLOAD_ONLY YES QUIET YES)
 # benchmark
 set (HIBF_BENCHMARK_VERSION 1.9.0)
 CPMDeclarePackage (benchmark

--- a/test/hibf-test.cmake
+++ b/test/hibf-test.cmake
@@ -13,6 +13,12 @@ cmake_minimum_required (VERSION 3.10...3.30)
 # have to be adapted or the option deactivated.
 option (HIBF_BENCHMARK_ALIGN_LOOPS "Pass -falign-loops=32 to the benchmark builds." ON)
 
+include (CheckIPOSupported)
+check_ipo_supported (RESULT HIBF_TEST_HAS_LTO OUTPUT HIBF_TEST_HAS_LTO_OUTPUT)
+if (HIBF_TEST_HAS_LTO)
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
+
 get_filename_component (HIBF_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
 add_subdirectory ("${HIBF_ROOT_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/hibf_lib")
 target_compile_options (hibf PUBLIC "-pedantic" "-Wall" "-Wextra" "-Werror")

--- a/test/tutorial/CMakeLists.txt
+++ b/test/tutorial/CMakeLists.txt
@@ -5,6 +5,12 @@
 cmake_minimum_required (VERSION 3.16...3.30)
 project (hibf_test_tutorial CXX)
 
+include (CheckIPOSupported)
+check_ipo_supported (RESULT HIBF_TEST_HAS_LTO OUTPUT HIBF_TEST_HAS_LTO_OUTPUT)
+if (HIBF_TEST_HAS_LTO)
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif ()
+
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 list (APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -5,9 +5,10 @@
 cmake_minimum_required (VERSION 3.10...3.30)
 project (hibf_util CXX)
 
-# https://cmake.org/cmake/help/latest/policy/CMP0135.html
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    cmake_policy (SET CMP0135 NEW)
+include (CheckIPOSupported)
+check_ipo_supported (RESULT HIBF_TEST_HAS_LTO OUTPUT HIBF_TEST_HAS_LTO_OUTPUT)
+if (HIBF_TEST_HAS_LTO)
+    set (CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif ()
 
 # Dependency: seqan::hibf


### PR DESCRIPTION
Force projects that include HIBF to enable CMAKE_INTERPROCEDURAL_OPTIMIZATION. 
CMake does not only detect the compiler flags, but also chooses programs that support the lto-plugin (ar, ranlib, ...). 
This means that exporting the CXX_FLAGS is not enough, because linking might fail due to the wrong programs being chosen.