### PR TITLE
[MISC] Make IBF operator== conditionally constexpr

### DIFF
--- a/include/hibf/interleaved_bloom_filter.hpp
+++ b/include/hibf/interleaved_bloom_filter.hpp
@@ -398,7 +398,7 @@ public:
     /*!\name Comparison operators
      * \{
      */
-    constexpr bool operator==(interleaved_bloom_filter const &) const = default;
+    HIBF_CONSTEXPR_VECTOR bool operator==(interleaved_bloom_filter const &) const = default;
     //!\}
 
     /*!\name Access


### PR DESCRIPTION
When adding the occupancy table (`std::vector`), the operator will also compare the `std::vector`.
`std::vector::operator==` is only `constexpr` if the stl version has already `constexpr std::vector`.